### PR TITLE
[FIX] FileObserver 스레드 종료 시 간헐적으로 무한 블로킹하는 현상 수정

### DIFF
--- a/Source/GA6thFinal_Framework/FileSystem/Core/FileObserver.h
+++ b/Source/GA6thFinal_Framework/FileSystem/Core/FileObserver.h
@@ -60,7 +60,6 @@ namespace File
         std::atomic<bool>       _isStart;       // Start 호출 여부
         std::atomic<bool>       _isObserving;   // 옵저버 스레드의 시작 여부
     private:
-        constexpr static UINT  BUFFER_SIZE = {1024 * 256};
         constexpr static DWORD NOTIFY_FILTERS =
             FILE_NOTIFY_CHANGE_SECURITY | FILE_NOTIFY_CHANGE_CREATION |
             FILE_NOTIFY_CHANGE_LAST_ACCESS | FILE_NOTIFY_CHANGE_LAST_WRITE |

--- a/Source/GA6thFinal_Framework/FileSystem/FileHelper.h
+++ b/Source/GA6thFinal_Framework/FileSystem/FileHelper.h
@@ -23,7 +23,7 @@ namespace File
     {
 #ifdef _DEBUG
         std::wstring debugMsg = L"FileSystem: " + msg + L'\n';
-        OutputDebugString(msg.c_str());
+        OutputDebugString(debugMsg.c_str());
 #endif
     }
 


### PR DESCRIPTION
## 🎯 반영 브랜치
fix/filesystem-> develop

---

## 🛠️ 변경 사항
- FileObserver 스레드 종료 시 간헐적으로 무한 블로킹하는 현상 수정. (약 50회 정도 종료 테스트 완료)
- 스레드 종료 확인 디버그 로그 추가

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #
- Jira Ticket Number: VG-
