### PR TITLE
[CI/VG-135] 부모 작업 로그 찍기

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -51,6 +51,9 @@ jobs:
           type=$(echo $response | jq -r '.fields.issuetype.name')
           echo "parent_type=$type" >> $GITHUB_OUTPUT
           
+      - name: Log parent_type
+        run: echo "Detected parent type is: ${{ steps.parent-type.outputs.parent_type }}"
+  
       - name: Create Task under Epic
         if: steps.parent-type.outputs.parent_type == '에픽'
         id: create-task


### PR DESCRIPTION
## 🎯 반영 브랜치
main <- fix/VG-135/update_create_jira_issue_action

---

## 🛠️ 변경 사항
- 부모로 작성된 작업의 타입을 출력하는 부분 추가

---

## ✅ 체크리스트
.

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #
- Jira Ticket Number: VG-135
