### PR TITLE
[fix/VG-239] 파일 Removed 이벤트의 empty Guid반환 오류 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/System/FileSystem.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/System/FileSystem.cpp
@@ -307,11 +307,13 @@ void EFileSystem::RemovedFile(const File::Path& path)
         const MetaData& meta      = spContext->GetMeta();
         File::Guid      guid      = meta.GetFileGuid();
 
-        spContext->OnFileRemoved(path);
+        auto notifierSet = GetNotifiers(path.extension());
+        for (auto& notifier : notifierSet)
+        {
+            notifier->OnFileRemoved(path);
+        } 
 
-        _pathToGuidTable.erase(path);
-        _guidToPathTable.erase(guid);
-        _contextTable.erase(spContext);
+        spContext->OnFileRemoved(path);
 
         // 부모 폴더에서 자신을 제거한다.
         File::Path parentPath = path.parent_path().generic_string();
@@ -320,12 +322,6 @@ void EFileSystem::RemovedFile(const File::Path& path)
         {
             wpFolderContext.lock()->_contextTable.erase(path.filename());
         }
-
-        auto notifierSet = GetNotifiers(path.extension());
-        for (auto& notifier : notifierSet)
-        {
-            notifier->OnFileRemoved(path);
-        } 
     }
 }
 


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-/feature_name

---

## 🛠️ 변경 사항
- 파일 Removed 이벤트의 empty Guid반환 오류 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #101
- Jira Ticket Number: VG-239
