### PR TITLE
[FAETURE/VG-28] 오브젝트 및 씬 직렬화 기능 버그 수정 및 에디터에서 할 수 있도록 추가

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Menu/Scene/EditorSceneMenu.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Menu/Scene/EditorSceneMenu.cpp
@@ -18,9 +18,12 @@ void EditorSceneMenuScenes::OnMenu()
                     ImGui::InputText(u8"이름"_c_str, &inputBuff);
                     if (ImGui::Button(u8"확인"_c_str))
                     {
-                        std::filesystem::path outPath = "Scenes";
-                        UmSceneManager.WriteEmptySceneToFile(inputBuff, outPath.string());
-                        ImGui::CloseCurrentPopup();
+                        if (inputBuff.empty() == false)
+                        {
+                            std::filesystem::path outPath = "Scenes";
+                            UmSceneManager.WriteEmptySceneToFile(inputBuff, outPath.string());
+                            ImGui::CloseCurrentPopup();
+                        }
                     }
                     ImGui::SameLine();
                     if (ImGui::Button(u8"취소"_c_str))

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
@@ -330,7 +330,9 @@ void EditorAssetBrowserTool::ContentsFrameEventAction(spFolderContext context)
     {
         if (nullptr != context)
         {
-            UmGameObjectFactory.WriteGameObjectFile(data.pTransform, context->GetPath().string());
+            File::Path path = context->GetPath();
+            path = std::filesystem::relative(path, UmFileSystem.GetRootPath());
+            UmGameObjectFactory.WriteGameObjectFile(data.pTransform, path.string());
         }
     }
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -169,8 +169,7 @@ void EditorHierarchyTool::HierarchyDropEvent()
                 fs::path extension = path.extension();
                 if (extension == UmGameObjectFactory.PREFAB_EXTENSION)
                 {
-                    YAML::Node node = YAML::LoadFile(path.string());
-                    UmGameObjectFactory.DeserializeToYaml(&node);
+                    UmGameObjectFactory.DeserializeToGuid(path.ToGuid());
                 }
                 else if (extension == UmSceneManager.SCENE_EXTENSION)
                 {

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Log/EditorLogsTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Log/EditorLogsTool.h
@@ -39,8 +39,10 @@ private:
 
 private:
     size_t prevLogCount = 0;
-    bool   _isMessagePush     = false;
-    bool   _editFilter  = false;
+    size_t notReadCount = 0;
+    bool _isMessagePush = false;
+    bool _editFilter  = false;
+    bool _isFocused = false;
     std::vector<std::tuple<int, std::string, LogLocation>> _drawLogList;
 
 protected:

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/ComponentFactory.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/ComponentFactory.cpp
@@ -27,7 +27,7 @@ bool EComponentFactory::InitalizeComponentFactory()
         if (m_scriptsDll != NULL)
             return false;
     }
-   
+    SetForegroundWindow(UmApplication.GetHwnd());
     if (m_scriptsDll != NULL)
     {
         //모든 컴포넌트 자원 회수

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/GameObjectFactory.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/GameObjectFactory.cpp
@@ -146,6 +146,12 @@ std::shared_ptr<GameObject> EGameObjectFactory::DeserializeToYaml(YAML::Node* pG
 
 std::shared_ptr<GameObject> EGameObjectFactory::DeserializeToGuid(const File::Guid& guid)
 {
+    if (UmComponentFactory.HasScript() == false)
+    {
+        UmLogger.Log(LogLevel::LEVEL_ERROR, u8"스크립트 빌드를 해주세요."_c_str);
+        return nullptr;
+    }
+
     auto iter = _prefabDataMap.find(guid);
     if (iter == _prefabDataMap.end())
     {
@@ -153,7 +159,14 @@ std::shared_ptr<GameObject> EGameObjectFactory::DeserializeToGuid(const File::Gu
         UmLogger.Log(LogLevel::LEVEL_ERROR, message);
         return nullptr;
     }
-    return DeserializeToYaml(&iter->second);
+    auto pObject = DeserializeToYaml(&iter->second);
+    std::vector<std::weak_ptr<GameObject>>& instanceList = _PrefavInstanceList[guid];
+    instanceList.emplace_back(pObject);
+    std::erase_if(instanceList, [](std::weak_ptr<GameObject>& weakObject)
+    { 
+        return weakObject.expired();
+    });
+    return pObject;
 }
 
 void EGameObjectFactory::WriteGameObjectFile(Transform* transform, std::string_view outPath)
@@ -186,8 +199,7 @@ void EGameObjectFactory::WriteGameObjectFile(Transform* transform, std::string_v
     }
 }
 
-std::shared_ptr<GameObject> EGameObjectFactory::MakeGameObject(
-    std::string_view typeid_name)
+std::shared_ptr<GameObject> EGameObjectFactory::MakeGameObject(std::string_view typeid_name)
 {
     std::shared_ptr<GameObject> newObject;
     auto findIter = _NewGameObjectFuncMap.find(typeid_name.data());

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/GameObjectFactory.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/GameObjectFactory.h
@@ -130,4 +130,7 @@ private:
 
     //프리팹 직렬화 데이터 모아두는 맵
     std::unordered_map<File::Guid, YAML::Node> _prefabDataMap;
+
+    // 인스턴스화된 프리팹 추적용
+    std::unordered_map<File::Guid, std::vector<std::weak_ptr<GameObject>>>  _PrefavInstanceList;      
 };

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
@@ -865,7 +865,15 @@ void ESceneManager::OnFileAdded(const File::Path& path)
     std::string nodeGuid = node["Guid"].as<std::string>();
     if (nodeGuid != guid)
     {
-        WriteSceneToFile(scene, path.parent_path().string(), true);
+        if (UmComponentFactory.HasScript() == false)
+        {
+            if (UmComponentFactory.InitalizeComponentFactory() == false)
+            {
+                return;
+            }
+        }    
+        std::filesystem::path relativeRootPath = std::filesystem::relative(path, UmFileSystem.GetRootPath());
+        WriteSceneToFile(scene, relativeRootPath.parent_path().string(), true);
     }
     
     std::string& loadScene = Application::IsEditor() ? _setting.MainScene : _setting.StartScene; 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/Utility/ImguiHelper.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/Utility/ImguiHelper.h
@@ -282,4 +282,16 @@ namespace ImGuiHelper
     /// <param name="toolTip :">출력할 내용</param>
     /// <returns>마우스 Hovered 여부</returns>
     bool HoveredToolTip(std::string_view toolTip);
+
+    /// <summary>
+    /// ImVec4를 선형보간합니다.
+    /// </summary>
+    /// <param name="a"></param>
+    /// <param name="b"></param>
+    /// <param name="t"></param>
+    /// <returns></returns>
+    inline constexpr ImVec4 ImVec4Lerp(const ImVec4& a, const ImVec4& b, float t)
+    {
+        return ImVec4(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t, a.w + (b.w - a.w) * t);
+    }
 }


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-28/scene_editor_prefab

---

## 🛠️ 변경 사항
- 로그 가독성 기능 강화
- 오브젝트 역직렬화 및 씬 역직렬화 GUID 사용하도록 수정
- 역직렬화된 Prefab 오브젝트들 GameObjectFactory가 추적하도록 수정
---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---
