### PR TITLE
[FIX/VG-261] Scene 재 로드 시 렌더러 컴포넌트에서 터지던 버그 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/GBufferPass.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/GBufferPass.cpp
@@ -205,7 +205,7 @@ void GBufferPass::DrawStaticTwoSidedMesh(ID3D12GraphicsCommandList* commandList)
     commandList->SetPipelineState(_psos[0].Get());
 
     UINT ID = 0;
-    for (auto& component : _ownerScene->_renderQueue)
+    for (auto& [isActive, component] : _ownerScene->_renderQueue)
     {
         const auto& model = component->GetModel();
         if (!model.get())

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderScene.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderScene.h
@@ -36,7 +36,7 @@ public:
     // 렌더신 시작시 한번만 호출
     void InitializeRenderScene();
     // 렌더할 메쉬 등록
-    void RegisterOnRenderQueue(MeshRenderer* renderable);
+    void RegisterOnRenderQueue(bool* isActive, MeshRenderer* renderable);
     // 렌더큐에서 삭제된건?? 물어봐야함.
 
     // 렌더 기술 등록
@@ -86,7 +86,7 @@ public:
     ComPtr<ID3D12Resource>      _depthStencilBuffer;
 
     // 렌더링할 목록
-    std::vector<MeshRenderer*>                  _renderQueue;
+    std::vector<std::pair<bool*, MeshRenderer*>>                  _renderQueue;
     
     //frame resource와 카메라 리소스.
     std::vector<std::shared_ptr<FrameResource>> _frameResources;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/Renderer.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/Renderer.h
@@ -18,7 +18,7 @@ public:
     ~Renderer();
 
 public:
-    void RegisterRenderQueue(MeshRenderer* component);
+    void RegisterRenderQueue(bool** isActive, MeshRenderer* component);
 
 public:
     void Initialize();
@@ -39,9 +39,10 @@ private:
 
 private:
     // imgui 전용 descriptor heap
-    ComPtr<ID3D12DescriptorHeap>                                  _imguiDescriptorHeap = nullptr;
+    ComPtr<ID3D12DescriptorHeap> _imguiDescriptorHeap = nullptr;
+
 private:
-    std::vector<MeshRenderer*>     _components;
+    std::vector<std::pair<bool, MeshRenderer*>>                   _components;
     std::unordered_map<std::string, std::shared_ptr<RenderScene>> _renderScenes;
-    UINT                           _currnetState;
+    UINT                                                          _currnetState;
 };

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Graphics/MeshRenderer.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Graphics/MeshRenderer.h
@@ -29,4 +29,5 @@ public:
 
 protected:
     std::shared_ptr<Model> _model;
+    bool*                  _isActive{nullptr};
 };

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Graphics/StaticMeshRenderer.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Graphics/StaticMeshRenderer.cpp
@@ -25,6 +25,7 @@ StaticMeshRenderer::StaticMeshRenderer()
 
 StaticMeshRenderer::~StaticMeshRenderer()
 {
+    //(*_isActive) = false;
 }
 
 void StaticMeshRenderer::Reset()
@@ -53,10 +54,13 @@ void StaticMeshRenderer::Start()
 void StaticMeshRenderer::OnEnable()
 {
     //if constexpr (!IS_EDITOR)
-        UmRenderer.RegisterRenderQueue(this);
+        UmRenderer.RegisterRenderQueue(&_isActive, this);
 }
 
-void StaticMeshRenderer::OnDisable() {}
+void StaticMeshRenderer::OnDisable()
+{
+    (*_isActive) = false;
+}
 
 void StaticMeshRenderer::Update() 
 {
@@ -74,7 +78,10 @@ void StaticMeshRenderer::Update()
 
 void StaticMeshRenderer::FixedUpdate() {}
 
-void StaticMeshRenderer::OnDestroy() {}
+void StaticMeshRenderer::OnDestroy()
+{
+    (*_isActive) = false;
+}
 
 void StaticMeshRenderer::OnApplicationQuit() {}
 


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-261/bug_render_component_dangling_pointer

---

## 🛠️ 변경 사항
- 어떤 작업을 했는지 요약
- Scene 재 로드 시 렌더러 컴포넌트에서 터지던 버그 수정
- 
---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #117 
- Jira Ticket Number: VG-261
