### PR TITLE
[FIX/VG-28] scene 파일, prefab 파일 저장시 경로 이상한곳에 저장하는 문제들 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
@@ -1,5 +1,4 @@
-﻿#include "EditorAssetBrowserTool.h"
-#include "pch.h"
+﻿#include "pch.h"
 
 namespace fs = std::filesystem;
 using namespace u8_literals;
@@ -414,8 +413,8 @@ void EditorAssetBrowserTool::ContentsFrameEventAction(spFolderContext context)
         DragDropTransform::Data data;
         if (ImGuiHelper::DragDrop::RecieveFrameDragDropEvent(DragDropTransform::KEY, &data))
         {
-            File::Path path = context->GetPath();
-            path = UmFileSystem.GetRelativePath(path);
+            std::filesystem::path path = context->GetPath();
+            path = std::filesystem::relative(path, UmFileSystem.GetAssetPath());
             UmGameObjectFactory.WriteGameObjectFile(data.pTransform, path.string());
         }
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.h
@@ -147,3 +147,4 @@ private:
 
     std::weak_ptr<EditorAssetObject> _this; // 자신 weak_ptr 객체
 };
+

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -311,8 +311,8 @@ void EditorHierarchyTool::OnFrame()
             {
                 if (ImGui::MenuItem("Save Scene"))
                 {
-                    std::string           path      = scene.Path;
-                    std::filesystem::path writePath = UmFileSystem.GetRelativePath(path).parent_path();
+                    std::filesystem::path writePath = (std::string)scene.Path;
+                    writePath = std::filesystem::relative(writePath, UmFileSystem.GetAssetPath()).parent_path();
                     UmSceneManager.WriteSceneToFile(scene, writePath.string(), true);
                     ImGui::CloseCurrentPopup();
                 }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
@@ -941,8 +941,9 @@ void ESceneManager::OnFileRegistered(const File::Path& path)
                 return;
             }
         }    
-        std::filesystem::path relativeRootPath = UmFileSystem.GetRelativePath(path);
-        WriteSceneToFile(scene, relativeRootPath.parent_path().string(), true);
+        std::filesystem::path writePath = path;
+        writePath = std::filesystem::relative(writePath, UmFileSystem.GetAssetPath()).parent_path();
+        WriteSceneToFile(scene, writePath.string(), true);
     }
     
     if (_loadFuncEvent)


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-28/scene_file_write_fix

---

## 🛠️ 변경 사항
- scene 파일, prefab 파일 저장시 경로 이상한곳에 저장하는 문제들 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---