### PR TITLE
[FIX/VG-32] 배경에 lighting 연산 안들어가게 만듬.

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/DeferredPBRLitPass.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/DeferredPBRLitPass.cpp
@@ -25,6 +25,10 @@ void DeferredPBRLitPass::Begin(ID3D12GraphicsCommandList* commandList)
     CD3DX12_RESOURCE_BARRIER br = CD3DX12_RESOURCE_BARRIER::Transition(
         rt.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
     commandList->ResourceBarrier(1, &br);
+    auto handle = _ownerScene->_meshLightingTarget->GetRTVHandle();
+    float clearValue = _ownerScene->_meshLightingTarget->clearValue;
+    Color clearColor = {clearValue, clearValue, clearValue,1.f};
+    commandList->ClearRenderTargetView(handle, clearColor, 0, nullptr);
     commandList->OMSetRenderTargets(1, &_ownerScene->_meshLightingTarget->GetRTVHandle(), FALSE, nullptr);
 
     commandList->RSSetViewports(1, &_viewPort);

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/GBufferPass.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/GBufferPass.cpp
@@ -28,9 +28,10 @@ void GBufferPass::Begin(ID3D12GraphicsCommandList* commandList)
         CD3DX12_RESOURCE_BARRIER br = CD3DX12_RESOURCE_BARRIER::Transition(
             gbuffer.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_RENDER_TARGET);
         commandList->ResourceBarrier(1, &br);
-
-        D3D12_CPU_DESCRIPTOR_HANDLE cpuHandle  = _ownerScene->_gBuffer[i]->GetRTVHandle();
-        commandList->ClearRenderTargetView(cpuHandle, _clearColor, 0, nullptr);
+        float clearValue    = _ownerScene->_gBuffer[i]->clearValue;
+        Color           clearColor = {clearValue, clearValue, clearValue, 1.f};
+        D3D12_CPU_DESCRIPTOR_HANDLE cpuHandle     = _ownerScene->_gBuffer[i]->GetRTVHandle();
+        commandList->ClearRenderTargetView(cpuHandle, clearColor, 0, nullptr);
     }
 
     // DepthStencil 상태 전이 + Clear

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/PBRLitTechnique.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/PBRLitTechnique.cpp
@@ -40,7 +40,6 @@ void PBRLitTechnique::InitGBufferPass()
 {
     std::shared_ptr<GBufferPass> gBufferPass = std::make_shared<GBufferPass>();
     gBufferPass->SetOwnerScene(_ownerScene);
-    gBufferPass->SetClearValue(Color(0.3f, 0.3f, 0.3f, 1.f));
     D3D12_VIEWPORT viewport{.TopLeftX = 0,
                             .TopLeftY = 0,
                             .Width    = (FLOAT)UmDevice.GetMode().Width,
@@ -59,7 +58,6 @@ void PBRLitTechnique::InitDeferredPass()
 {
     std::shared_ptr<DeferredPBRLitPass> litPass = std::make_shared<DeferredPBRLitPass>();
     litPass->SetOwnerScene(_ownerScene);
-    litPass->SetClearValue(Color(0.3f, 0.3f, 0.3f, 1.f));
     D3D12_VIEWPORT viewport{.TopLeftX = 0,
                             .TopLeftY = 0,
                             .Width    = (FLOAT)UmDevice.GetMode().Width,

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderScene.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderScene.cpp
@@ -143,16 +143,16 @@ void RenderScene::CreateRenderTarget()
     for (UINT i = 0; i <= GBuffer::WORLDPOSITION; ++i)
     {
         _gBuffer[i] = std::make_shared<RenderTarget>();
-        _gBuffer[i]->Initialize(DXGI_FORMAT_R32G32B32A32_FLOAT);
+        _gBuffer[i]->Initialize(DXGI_FORMAT_R32G32B32A32_FLOAT, 0.247f);
         _gBuffer[i]->CreateShaderResourceView();
     }
   
     _gBuffer[GBuffer::DEPTH] = std::make_shared<RenderTarget>();
-    _gBuffer[GBuffer::DEPTH]->Initialize(DXGI_FORMAT_R32_FLOAT);
+    _gBuffer[GBuffer::DEPTH]->Initialize(DXGI_FORMAT_R32_FLOAT, 1.f);
     _gBuffer[GBuffer::DEPTH]->CreateShaderResourceView();
     
     _gBuffer[GBuffer::CUSTOMDEPTH] = std::make_shared<RenderTarget>();
-    _gBuffer[GBuffer::CUSTOMDEPTH]->Initialize(DXGI_FORMAT_R32_UINT);
+    _gBuffer[GBuffer::CUSTOMDEPTH]->Initialize(DXGI_FORMAT_R32_UINT, 1.f);
     _gBuffer[GBuffer::CUSTOMDEPTH]->CreateShaderResourceView();
     
 
@@ -162,13 +162,13 @@ void RenderScene::CreateRenderTarget()
     for (UINT i = 0; i < _renderTargetPoolCount; ++i)
     {
         _renderTargets[i] = std::make_shared<RenderTarget>();
-        _renderTargets[i]->Initialize(DXGI_FORMAT_R32G32B32A32_FLOAT);
+        _renderTargets[i]->Initialize(DXGI_FORMAT_R32G32B32A32_FLOAT, 0.247f);
         _renderTargets[i]->CreateShaderResourceView();
     }
 
     // 메쉬 음영처리가 된 타겟 하나 생성 -> 이 타겟을 가져와서 후처리를 진행해야함.
     _meshLightingTarget = std::make_shared<RenderTarget>();
-    _meshLightingTarget->Initialize(DXGI_FORMAT_R32G32B32A32_FLOAT);
+    _meshLightingTarget->Initialize(DXGI_FORMAT_R32G32B32A32_FLOAT, 0.247f);
     _meshLightingTarget->CreateShaderResourceView();
 }
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderTarget.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderTarget.cpp
@@ -1,8 +1,9 @@
 ﻿#include "pch.h"
 #include "RenderTarget.h"
 
-HRESULT RenderTarget::Initialize(DXGI_FORMAT format)
+HRESULT RenderTarget::Initialize(DXGI_FORMAT format, FLOAT clearColor)
 {
+    clearValue                  = clearColor;
     _format                     = format;
     ComPtr<ID3D12Device> device = UmDevice.GetDevice();
     D3D12_RESOURCE_DESC  desc{.Dimension        = D3D12_RESOURCE_DIMENSION_TEXTURE2D,
@@ -17,10 +18,10 @@ HRESULT RenderTarget::Initialize(DXGI_FORMAT format)
                               .Flags  = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET};
 
     CD3DX12_HEAP_PROPERTIES property(D3D12_HEAP_TYPE_DEFAULT);
-
+    
     D3D12_CLEAR_VALUE clearValue{
         .Format = _format,
-        .Color  = {0.3f, 0.3f, 0.3f, 1.f},
+        .Color  = {clearColor, clearColor, clearColor,1.f},
     };
     // committedReosurce로 임시로 생성
     UmDevice.GetDevice()->CreateCommittedResource(&property, D3D12_HEAP_FLAG_NONE, &desc,

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderTarget.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderTarget.h
@@ -12,8 +12,11 @@ public:
     ComPtr<ID3D12Resource>             GetResource() { return _resource; }
 
 public:
-    HRESULT Initialize(DXGI_FORMAT format);
+    HRESULT Initialize(DXGI_FORMAT format, FLOAT clearColor);
     void    CreateShaderResourceView();
+
+public:
+    FLOAT clearValue;
 
 private:
     ComPtr<ID3D12Resource>      _resource;

--- a/Source/GA6thFinal_Framework/Shaders/ps_gbuffer.hlsl
+++ b/Source/GA6thFinal_Framework/Shaders/ps_gbuffer.hlsl
@@ -25,7 +25,6 @@ struct PSOutput
 #define NORMAL 1
 #define ORM 2
 #define EMISSIVE 3
-
 struct Material
 {
     uint ID[4];

--- a/Source/GA6thFinal_Framework/Shaders/ps_pbr_lighting.hlsl
+++ b/Source/GA6thFinal_Framework/Shaders/ps_pbr_lighting.hlsl
@@ -13,7 +13,7 @@ struct PSInput
 #define ORM 2
 #define EMISSIVE 3
 #define WORLDPOSITION 4
-
+#define DEPTH 5
 
 ConstantBuffer<NumLight> num_light : register(b0);
 StructuredBuffer<DirectionalLight> directionalLights;
@@ -26,6 +26,11 @@ SamplerState samLinear_wrap;
 float4 ps_main(PSInput input) : SV_Target0
 {
     float3 albedo = gBuffers[BASECOLOR].Sample(samLinear_wrap, input.uv).rgb;
+    float depth = gBuffers[DEPTH].Sample(samLinear_wrap, input.uv).r;
+    if (depth == 1.f)
+    {
+        discard;
+    }
     albedo = pow(albedo, 2.2);
     
     float3 normal = gBuffers[NORMAL].Sample(samLinear_wrap, input.uv).rgb;


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-32/dx12_graphics_core_develop

---

## 🛠️ 변경 사항
- 배경에 lighting 연산 안들어감. 

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #
- Jira Ticket Number: VG-32
