### PR TITLE
[FIX/VG-29] 윈도우 닫기 프로젝트 로드 안했을 시 무시되는 버그 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/FileSystemModule.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/FileSystemModule.cpp
@@ -137,9 +137,12 @@ bool FileSystemModule::FileSystemWinProc(HWND hwnd, UINT msg, WPARAM wParam, LPA
     {
         case WM_CLOSE: 
         {
-            if (IDOK != UmFileSystem.SaveProjectWithMessageBox())
+            if (true == UmFileSystem.IsLoadedProject())
             {
-                return true;
+                if (IDCANCEL == UmFileSystem.SaveProjectWithMessageBox())
+                {
+                    return true;
+                }
             }
             // 이후 처리 동작은 Application이 호출한다.
             break;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/System/FileSystem.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/System/FileSystem.cpp
@@ -177,15 +177,16 @@ int EFileSystem::SaveProjectWithMessageBox()
     std::wstring msg    = L"현재 프로젝트를 저장하시겠습니까?"; 
     std::wstring title  = L"Save Project";
     HWND         hwnd   = UmApplication.GetHwnd();
+    UINT         style  = MB_YESNOCANCEL | MB_DEFBUTTON1; // 기본 버튼을 YES로 설정
 
     int msgResult = MessageBox(
         hwnd,                       // 부모 창 핸들 (NULL로 하면 독립적 메시지 박스)
         msg.c_str(),                // 메시지 텍스트
         title.c_str(),              // 메시지 박스 제목
-        MB_OKCANCEL                 // 스타일
+        style                       // 스타일
     );
 
-    if (msgResult == IDOK)
+    if (msgResult == IDYES)
     {
         SaveProject();
     }
@@ -238,6 +239,11 @@ void EFileSystem::ObserverShutDown()
         delete _observer;
         _observer = nullptr;
     }
+}
+
+bool EFileSystem::IsLoadedProject() const
+{
+    return !_projectData.IsNull();
 }
 
 bool EFileSystem::IsVaildGuid(const File::Guid& guid) const

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/System/FileSystem.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/System/FileSystem.h
@@ -38,6 +38,7 @@ public:
     inline const File::Path& GetAssetPath() const { return _assetPath; }
     inline const File::Path& GetSettingPath() const { return _settingPath; }
 
+    bool IsLoadedProject() const;
     bool IsVaildGuid(const File::Guid& guid) const;
     bool IsValidExtension(const File::FString& ext) const;
     bool IsSameContext(std::weak_ptr<File::Context> left, std::weak_ptr<File::Context> right) const;


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-29/file_system
---

## 🛠️ 변경 사항
- 윈도우 닫기 버튼 누를 시 프로젝트 로드 안되어있을 때 무시되는 버그 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #
- Jira Ticket Number: VG-29
