### PR TITLE
[FIX/VG-29] 에디터 AssetBrowser 입력 포커스 수정 및 LogTool Crash현상 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
@@ -429,10 +429,11 @@ void EditorAssetBrowserTool::ContentsFrameEventAction(spFolderContext context)
 
     const File::Path& curPath = context->GetPath();
 
-    bool isSelected   = UmFileSystem.IsSameContext(_selectedContext->GetContext(), context);
-    bool isRename     = browserFlags[FLAG_IS_RENAME];
-    bool isItemActive = ImGui::IsItemActive();  // 셀렉터블이 눌렸는지
-    bool isHovered    = ImGui::IsItemHovered(); // 셀렉터블이 호버링 되었는지
+    bool isSelected     = UmFileSystem.IsSameContext(_selectedContext->GetContext(), context);
+    bool isRename       = browserFlags[FLAG_IS_RENAME];
+    bool isFrameFocused = IsFocusFrame();         // 윈도우 포커스 여부
+    bool isItemActive   = ImGui::IsItemActive();  // 셀렉터블이 눌렸는지
+    bool isHovered      = ImGui::IsItemHovered(); // 셀렉터블이 호버링 되었는지
 
     bool isClickedLeft  = isHovered && ImGui::IsMouseClicked(0); // 마우스 왼 클릭
     bool isClickedRight = isHovered && ImGui::IsMouseClicked(1); // 마우스 오른 클릭
@@ -459,7 +460,7 @@ void EditorAssetBrowserTool::ContentsFrameEventAction(spFolderContext context)
             UmGameObjectFactory.WriteGameObjectFile(data.pTransform, path.string());
         }
 
-        if (false == isRename)
+        if (true == isFrameFocused && false == isRename)
         {
             if (true == isKeyBackSpace)
             {
@@ -669,7 +670,7 @@ void EditorAssetBrowserTool::ItemInputAction(spContext context, const char* mode
     bool isParent       = (0 == strcmp(mode, "parent"));
     bool isSelected     = UmFileSystem.IsSameContext(_selectedContext->GetContext(), context);
     bool isRename       = browserFlags[FLAG_IS_RENAME];
-    bool isFrameFocused = ImGui::IsWindowFocused();               // 윈도우 포커스 여부
+    bool isFrameFocused = IsFocusFrame();                         // 윈도우 포커스 여부
     bool isItemActive   = ImGui::IsItemActive();                  // 셀렉터블이 눌렸는지
     bool isItemHovered  = ImGui::IsItemHovered();                 // 셀렉터블이 호버링 되었는지
     bool isItemFocused  = ImGui::IsItemFocused() && io.NavActive; // 셀렉터블이 포커스 되었는지
@@ -692,7 +693,7 @@ void EditorAssetBrowserTool::ItemInputAction(spContext context, const char* mode
     bool isKeyCopy  = ctrl && c; // Ctrl + C
     bool isKeyPaste = ctrl && v; // Ctrl + V
 
-    if (true == isItemFocused)
+    if (true == isFrameFocused && true == isItemFocused)
     {
         if (true == isMouseDouble || true == iskeyEnter)
         {

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.h
@@ -78,7 +78,6 @@ private:
     void ShowDeletePopupBox(wpContext context);
     void ShowSameFilePopupBox();
 
-
 private:
     void ProcessEnterAction(spContext context);
     void ProcessMoveAction(wpContext srcContext, wpFolderContext dstContext);

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.cpp
@@ -69,10 +69,14 @@ void EditorCommandTool::OnFrameRender()
                 ImGui::PopStyleColor(2);
             }
         }
+
         auto redoBegin = manager.RedoStackBegin();
         auto redoEnd   = manager.RedoStackEnd();
 
-        for (auto itr = redoBegin; itr != redoEnd; ++itr, ++index)
+        using Iterator = decltype(redoBegin);
+        std::reverse_iterator<Iterator> redoRbegin(redoEnd);
+        std::reverse_iterator<Iterator> redoRend(redoBegin);
+        for (auto itr = redoRbegin; itr != redoRend; ++itr, ++index)
         {
             auto& command = *itr;
             if (nullptr != command)

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Log/EditorLogsTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Log/EditorLogsTool.cpp
@@ -100,6 +100,10 @@ void EditorLogsTool::OnPreFrameBegin()
 
 void EditorLogsTool::OnPostFrameBegin()
 {
+    if (notReadCount > 0)
+    {
+        ImGui::PopStyleColor();
+    }
 }
 
 void EditorLogsTool::OnFrameRender() 
@@ -108,7 +112,6 @@ void EditorLogsTool::OnFrameRender()
     _isWindowHovered = ImGui::IsWindowHovered();
     if (notReadCount > 0)
     {
-        ImGui::PopStyleColor();
         if (_isWindowFocused == true || _isWindowHovered == true)
         {
             static bool once = false;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
@@ -55,7 +55,7 @@ protected:
     REFLECT_FIELDS_BEGIN(EditorTool)
     std::array<float, 3> CameraPosition{};
     std::array<float, 4> CameraRotation{};
-    float  CameraFovDegree = 70.f;
+    float  CameraFovDegree   = 70.f;
     float  CameraAspect      = 1.0f;
     float  CameraNearZ       = 0.01f;
     float  CameraFarZ        = 10000.f;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/Gui/DockWindow/EditorDockWindow.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/Gui/DockWindow/EditorDockWindow.cpp
@@ -163,23 +163,19 @@ void EditorDockWindow::PushDockStyle()
         ImGui::SetNextWindowViewport(viewport->ID);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+        _pushedStyleCount += 2;
     }
     if (_dockWindowOptionFlags & DOCKWINDOW_FLAGS_PADDING)
     {
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+        _pushedStyleCount += 1;
     }
 }
 
 void EditorDockWindow::PopDockStyle() 
 {
-    if (_dockWindowOptionFlags & DOCKWINDOW_FLAGS_FULLSCREEN)
-    {
-        ImGui::PopStyleVar(2);
-    }
-    if (_dockWindowOptionFlags & DOCKWINDOW_FLAGS_PADDING)
-    {
-        ImGui::PopStyleVar();
-    }
+    ImGui::PopStyleVar(_pushedStyleCount);
+    _pushedStyleCount = 0;
 }
 
 void EditorDockWindow::CreateDockLayoutNode(ImGuiDir direction, float ratio)

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/Gui/DockWindow/EditorDockWindow.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/Gui/DockWindow/EditorDockWindow.h
@@ -87,6 +87,9 @@ private:
     std::vector<DockSplitInfo>          _dockSplitLayoutID;         /* 도킹 영역에 대한 ID값 */
     std::unordered_map<int, ImGuiID>    _dockSplitIDTable;          /* 도킹 영역에 대한 ID값 */
 
+private:
+    int _pushedStyleCount = 0; // [internal] PushStyleVar 호출 횟수
+
 public:
     /* 옵션 플래그에 대한 설정 */
     inline void         SetDockWindowFlags(EditorDockWindowFlags flags) { _dockWindowOptionFlags = flags; }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/Gui/Tool/EditorTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/Gui/Tool/EditorTool.cpp
@@ -171,22 +171,22 @@ void EditorTool::ProcessFocusFrame()
 {
     if (false == _isFirstTick)
     {
-        if (true == ImGui::IsWindowFocused(ImGuiFocusedFlags_DockHierarchy | ImGuiFocusedFlags_RootAndChildWindows))
+        if (true == ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows))
         {
             if (false == _isFrameFocused)
             {
+                _isFrameFocused = true;
                 OnFrameFocusEnter();
             }
             OnFrameFocusStay();
-            _isFrameFocused = true;
         }
         else
         {
             if (true == _isFrameFocused)
             {
+                _isFrameFocused = false;
                 OnFrameFocusExit();
             }
-            _isFrameFocused = false;
         }
     }
 }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/Gui/Tool/EditorTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/Gui/Tool/EditorTool.h
@@ -139,5 +139,7 @@ public:
     inline bool         IsDrawable() { return _isDrawable; }
     /*                  Begin과 End 사이의 작업 중인지 여부 */
     inline bool         IsBeginningFrame() { return _isBeginningFrame; }
+    /*                  해당 프레임이 포커싱 중인지 여부 */ 
+    inline bool         IsFocusFrame() { return _isFrameFocused; }
 };
 


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-29/editor_system

---

## 🛠️ 변경 사항
- EditorLogTool StylePop 누락 수정
- EditorTool 포커싱 여부 반환 함수 추가 (bool IsFocusFrame())
- 에셋 브라우저 포커싱에만 입력 받도록 수정
- 커맨드 툴 Redo리스트 역순으로 출력하게 수정


---

## ✅ 체크리스트
- [ ] 코드에 불필요한 로그는 제거했나요?
- [ ] 코드에 불필요한 주석은 제거했나요?
- [ ] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [ ] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #
- Jira Ticket Number: VG-29
