### PR TITLE
[FIX/VG-28] scene 에디터 포커스일때만 카메라 움직이게 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -58,8 +58,6 @@ void EditorSceneTool::OnFrameRender()
 {
     _window = ImGui::GetCurrentWindow();
     DragDropEvent();
-    _camera->Update();
-
     SetCamera();    
     DrawSceneView();
     DrawManipulate();
@@ -71,6 +69,7 @@ void EditorSceneTool::OnFrameEnd()
 
 void EditorSceneTool::OnFrameFocusStay()
 {
+    _camera->Update();
     UpdateMode();
 }
     


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-28/scene_editor_fix

---

## 🛠️ 변경 사항
- scene 에디터 포커스일때만 카메라 움직이게 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #
- Jira Ticket Number: VG-28
