### PR TITLE
[FIX/VG-32] 씬 초기화 안되는 버그 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/Renderer.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/Renderer.cpp
@@ -143,6 +143,7 @@ void Renderer::Initialize()
 
         // Editor Scene
         scene = std::make_unique<RenderScene>("Editor");
+        scene->InitializeRenderScene();
         scene->AddRenderTechnique(std::make_unique<SkyBoxRenderTechnique>());
         scene->AddRenderTechnique(std::make_unique<PBRLitTechnique>());
         _renderScenes["Editor"] = std::move(scene);


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-/32feature_dx12_graphics_core_devleop

---

## 🛠️ 변경 사항
- Scene Initialize 누락된 부분 추가

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?