### PR TITLE
[FIX/VG-26] 전역 변수로 연결된 컨트롤러 관리 방식 변경

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/InputCore/Adapter/Controller/XInput/XInputAdapter.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/InputCore/Adapter/Controller/XInput/XInputAdapter.cpp
@@ -3,6 +3,11 @@
 
 namespace Input
 {
+    namespace
+    {
+        std::unordered_set<Controller::ID> ConnectedControllers;
+    }
+
     Controller::ID XInputAdapter::Connect() const
     {
         for (Controller::ID id = 0; id < Controller::MAX_CONNECTION_COUNT; ++id)
@@ -10,9 +15,9 @@ namespace Input
             XINPUT_STATE xState{};
             if (const DWORD result = XInputGetState(id, &xState);
                 result == ERROR_SUCCESS && 
-                !_connectedControllers.contains(id))
+                !ConnectedControllers.contains(id))
             {
-                _connectedControllers.insert(id);
+                ConnectedControllers.insert(id);
                 return id;
             }
         }
@@ -40,7 +45,7 @@ namespace Input
             return INPUT_ERROR_SUCCESS;
         }
         case ERROR_DEVICE_NOT_CONNECTED:
-            _connectedControllers.erase(id);
+            ConnectedControllers.erase(id);
             return INPUT_ERROR_LOST_DEVICE;
         default:
             return INPUT_ERROR_UNKNOWN;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/InputCore/Adapter/Controller/XInput/XInputAdapter.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/InputCore/Adapter/Controller/XInput/XInputAdapter.h
@@ -20,7 +20,5 @@ namespace Input
 
         static void NormalizeStick(SHORT xValue, SHORT yValue, SHORT deadZoneValue,
                                    Controller::ThumbStickAxis* normalizedStick);
-
-        static std::unordered_set<Controller::ID> _connectedControllers;
     };
 } // namespace Input


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-26/input

---

## 🛠️ 변경 사항
- 연결된 컨트롤러 ID 관리를 CPP 전역 변수로 변경

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #
- Jira Ticket Number: VG-26
