### PR TITLE
[REFACTOR/VG-28] scene input refactor

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/Command/FocusCommand.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/Command/FocusCommand.cpp
@@ -4,14 +4,14 @@ Command::Hierarchy::FocusCommand::~FocusCommand() = default;
 void Command::Hierarchy::FocusCommand::Execute()
 {
     Super::Execute();
-    EditorHierarchyTool::HierarchyFocusObjWeak = _newFocused;
+    EditorHierarchyTool::SetFocusObject(_newFocused);
     EditorSceneTool::SetManipulateObject(_newFocused);
 }
 
 void Command::Hierarchy::FocusCommand::Undo()
 {
     Super::Undo();
-    EditorHierarchyTool::HierarchyFocusObjWeak = _oldFocused;
+    EditorHierarchyTool::SetFocusObject(_oldFocused);
     EditorSceneTool::SetManipulateObject(_oldFocused);
 }
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -208,8 +208,12 @@ void EditorHierarchyTool::TransformTreeNode(Transform& node, const std::shared_p
         {
             Transform* nodeRoot = node.Root;
             nodeRoot = nodeRoot ? nodeRoot : &node;
-            Transform* focusRoot = focusObject ? focusObject->transform->Root : nullptr;
-            focusRoot = focusRoot ? focusRoot : &focusObject->transform;
+            Transform* focusRoot = nullptr;
+            if (focusObject)
+            {
+                focusRoot = focusObject->transform->Root;
+                focusRoot = focusRoot ? focusRoot : &focusObject->transform;
+            }
             if (nodeRoot && focusRoot)
             {
                 if (nodeRoot == focusRoot)

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -288,6 +288,7 @@ void EditorHierarchyTool::SetFocusObject(const std::weak_ptr<GameObject>& object
                 mesh->Renderer->SetCustomDepth(PostProcess::OUTLINE | PostProcess::BLOOM);
             }
         }     
+        _isOpenFocusObj = true;
     }
 }
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -5,6 +5,7 @@
 #include "Command/PackPrefabCommand.h"
 #include "Command/DropPrefabCommand.h"
 #include "Engine/GraphicsCore/Light.h"
+#include <Engine/GraphicsCore/MeshRenderer.h>
 #include "UmScripts.h"
 
 using namespace u8_literals;
@@ -257,6 +258,38 @@ void EditorHierarchyTool::TransformTreeNode(Transform& node, const std::shared_p
     }
 }
 
+
+void EditorHierarchyTool::SetFocusObject(const std::weak_ptr<GameObject>& object) 
+{
+    if (false == HierarchyFocusObjWeak.expired())
+    {
+        auto prevFocus = HierarchyFocusObjWeak.lock();
+        for (int i = 0; i < prevFocus->GetComponentCount(); ++i)
+        {
+            MeshComponent* mesh = prevFocus->GetComponentAtIndex<MeshComponent>(i);
+            if (mesh)
+            {
+                mesh->Renderer->SetCustomDepth(0);
+                mesh->Renderer->SetCustomDepth(PostProcess::BLOOM);
+            }
+        }     
+    }
+
+    HierarchyFocusObjWeak = object;
+
+    if (false == HierarchyFocusObjWeak.expired())
+    {
+        auto focus = HierarchyFocusObjWeak.lock();
+        for (int i = 0; i < focus->GetComponentCount(); ++i)
+        {
+            MeshComponent* mesh = focus->GetComponentAtIndex<MeshComponent>(i);
+            if (mesh)
+            {
+                mesh->Renderer->SetCustomDepth(PostProcess::OUTLINE | PostProcess::BLOOM);
+            }
+        }     
+    }
+}
 
 EditorHierarchyTool::EditorHierarchyTool()
 {

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -20,7 +20,7 @@ void EditorHierarchyTool::TransformTreeNode(Transform& node, const std::shared_p
         bool result = ImGui::IsMouseReleased(ImGuiMouseButton_Left) && ImGui::IsItemHovered();
         if (result)
         {
-            auto oldWp = EditorHierarchyTool::HierarchyFocusObjWeak;
+            auto oldWp = EditorHierarchyTool::static_hierarchyFocusObjWeak;
             auto newWp = node.gameObject->GetWeakPtr();
             if (false == EditorInspectorTool::IsLockFocus() && false == EditorInspectorTool::IsFocusObject(newWp))
             {
@@ -204,11 +204,11 @@ void EditorHierarchyTool::TransformTreeNode(Transform& node, const std::shared_p
     {
         ImGui::PushID(&node);
         bool isPushStyle = PushFocusStyle();
-        if (_isOpenFocusObj)
+        if (static_isOpenFocusObj)
         {
             Transform* nodeRoot = node.Root;
             nodeRoot = nodeRoot ? nodeRoot : &node;
-            Transform* focusRoot = focusObject->transform->Root;
+            Transform* focusRoot = focusObject ? focusObject->transform->Root : nullptr;
             focusRoot = focusRoot ? focusRoot : &focusObject->transform;
             if (nodeRoot && focusRoot)
             {
@@ -220,7 +220,7 @@ void EditorHierarchyTool::TransformTreeNode(Transform& node, const std::shared_p
                     }
                     else
                     {
-                        _isOpenFocusObj = false;
+                        static_isOpenFocusObj = false;
                     }
                 }
             }
@@ -261,9 +261,9 @@ void EditorHierarchyTool::TransformTreeNode(Transform& node, const std::shared_p
 
 void EditorHierarchyTool::SetFocusObject(const std::weak_ptr<GameObject>& object) 
 {
-    if (false == HierarchyFocusObjWeak.expired())
+    if (false == static_hierarchyFocusObjWeak.expired())
     {
-        auto prevFocus = HierarchyFocusObjWeak.lock();
+        auto prevFocus = static_hierarchyFocusObjWeak.lock();
         for (int i = 0; i < prevFocus->GetComponentCount(); ++i)
         {
             MeshComponent* mesh = prevFocus->GetComponentAtIndex<MeshComponent>(i);
@@ -275,11 +275,11 @@ void EditorHierarchyTool::SetFocusObject(const std::weak_ptr<GameObject>& object
         }     
     }
 
-    HierarchyFocusObjWeak = object;
+    static_hierarchyFocusObjWeak = object;
 
-    if (false == HierarchyFocusObjWeak.expired())
+    if (false == static_hierarchyFocusObjWeak.expired())
     {
-        auto focus = HierarchyFocusObjWeak.lock();
+        auto focus = static_hierarchyFocusObjWeak.lock();
         for (int i = 0; i < focus->GetComponentCount(); ++i)
         {
             MeshComponent* mesh = focus->GetComponentAtIndex<MeshComponent>(i);
@@ -288,7 +288,7 @@ void EditorHierarchyTool::SetFocusObject(const std::weak_ptr<GameObject>& object
                 mesh->Renderer->SetCustomDepth(PostProcess::OUTLINE | PostProcess::BLOOM);
             }
         }     
-        _isOpenFocusObj = true;
+        static_isOpenFocusObj = true;
     }
 }
 
@@ -474,9 +474,9 @@ void EditorHierarchyTool::KeyboardEvent()
         {
             if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_Delete, false))
             {
-                if (false == HierarchyFocusObjWeak.expired())
+                if (false == static_hierarchyFocusObjWeak.expired())
                 {
-                    auto object = HierarchyFocusObjWeak.lock();
+                    auto object                = static_hierarchyFocusObjWeak.lock();
                     object->GetScene().IsDirty = true;
                     UmCommandManager.Do<Command::EditorScene::DestroyGameObjectCommand>(object.get());
                 }             
@@ -487,7 +487,7 @@ void EditorHierarchyTool::KeyboardEvent()
 
 void EditorHierarchyTool::OnFrameRender()
 {
-    std::shared_ptr<GameObject> focusObject = HierarchyFocusObjWeak.lock();
+    std::shared_ptr<GameObject> focusObject = static_hierarchyFocusObjWeak.lock();
     _window = ImGui::GetCurrentWindow();
     HierarchyRightClickEvent();
     HierarchyDropEvent();
@@ -555,7 +555,7 @@ void EditorHierarchyTool::OnFrameRender()
             }
             ImGui::PopID();
         }
-        _isOpenFocusObj = false;
+        static_isOpenFocusObj = false;
     }
 
     if (_isPlay)

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.h
@@ -5,8 +5,11 @@ class HierarchyFindTool;
 class EditorHierarchyTool
     : public EditorTool
 {
-public:
     inline static std::weak_ptr<GameObject> HierarchyFocusObjWeak;
+public:
+    static void SetFocusObject(const std::weak_ptr<GameObject>& object);
+    static const std::weak_ptr<GameObject>& GetFocusObject() { return HierarchyFocusObjWeak; }
+
     EditorHierarchyTool();
     virtual ~EditorHierarchyTool();
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.h
@@ -5,12 +5,12 @@ class HierarchyFindTool;
 class EditorHierarchyTool
     : public EditorTool
 {
-    inline static std::weak_ptr<GameObject> HierarchyFocusObjWeak;
-    inline static bool                      _isOpenFocusObj = false;
+    inline static std::weak_ptr<GameObject> static_hierarchyFocusObjWeak;
+    inline static bool                      static_isOpenFocusObj = false;
 
 public:
     static void SetFocusObject(const std::weak_ptr<GameObject>& object);
-    static const std::weak_ptr<GameObject>& GetFocusObject() { return HierarchyFocusObjWeak; }
+    static const std::weak_ptr<GameObject>& GetFocusObject() { return static_hierarchyFocusObjWeak; }
 
     EditorHierarchyTool();
     virtual ~EditorHierarchyTool();
@@ -19,7 +19,7 @@ public:
     static void ImGuiNewGameObjectMenuItems();
 
     /*포커싱된 오브젝트의 트리 노드를 1회 Open 합니다.*/
-    void OpenFocusObjectTree() { _isOpenFocusObj = true; }
+    void OpenFocusObjectTree() { static_isOpenFocusObj = true; }
 
 private:
     void TransformTreeNode(Transform& node, const std::shared_ptr<GameObject>& focusObject);

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.h
@@ -6,6 +6,8 @@ class EditorHierarchyTool
     : public EditorTool
 {
     inline static std::weak_ptr<GameObject> HierarchyFocusObjWeak;
+    inline static bool                      _isOpenFocusObj = false;
+
 public:
     static void SetFocusObject(const std::weak_ptr<GameObject>& object);
     static const std::weak_ptr<GameObject>& GetFocusObject() { return HierarchyFocusObjWeak; }
@@ -49,7 +51,6 @@ private:
 
     ImGuiWindow* _window = nullptr;
     bool         _isPlay = false;
-    bool         _isOpenFocusObj = false;
 
     EditorDockWindow* _dockWindow = nullptr;
     EditorSceneTool*  _editorSceneTool = nullptr;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/HierarchyFindTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/HierarchyFindTool.cpp
@@ -108,7 +108,7 @@ void HierarchyFindTool::DrawFindList()
                         {
                             if (ImGui::Selectable(name.data()))
                             {
-                                EditorHierarchyTool::HierarchyFocusObjWeak = object;
+                                EditorHierarchyTool::SetFocusObject(object);
                                 EditorInspectorTool::SetFocusObject(object);
                             }
                         }
@@ -138,7 +138,7 @@ void HierarchyFindTool::DrawFindList()
                 {
                     if (ImGui::Selectable(name.data()))
                     {
-                        EditorHierarchyTool::HierarchyFocusObjWeak = object;
+                        EditorHierarchyTool::SetFocusObject(object);
                         EditorInspectorTool::SetFocusObject(object);
                         _editorHierarchyTool->SetFocusFrame();
                         _editorHierarchyTool->OpenFocusObjectTree();

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/Command/EditorSceneCommands.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/Command/EditorSceneCommands.cpp
@@ -26,10 +26,10 @@ void Command::EditorScene::DestroyGameObjectCommand::Execute()
     rootObject->ActiveSelf = false;
     UmSceneManager.AddDestroyObjectQueue(rootObject.get());
 
-    if (EditorHierarchyTool::HierarchyFocusObjWeak.lock() == rootObject)
+    if (EditorHierarchyTool::GetFocusObject().lock() == rootObject)
     {
         std::weak_ptr<GameObject> empty;
-        EditorHierarchyTool::HierarchyFocusObjWeak = empty;
+        EditorHierarchyTool::SetFocusObject(empty);
         _isFocus = true;
     }
     if (EditorInspectorTool::GetFocusObject().lock() == rootObject)
@@ -53,7 +53,7 @@ void Command::EditorScene::DestroyGameObjectCommand::Undo()
 
     if (_isFocus)
     {
-        EditorHierarchyTool::HierarchyFocusObjWeak = rootObject;
+        EditorHierarchyTool::SetFocusObject(rootObject);
         EditorInspectorTool::SetFocusObject(rootObject);
     }
 }
@@ -99,10 +99,10 @@ void Command::EditorScene::NewGameObjectCommand::Undo()
     _newObject->ActiveSelf = false;
     _newObject->transform->DetachChildren();
     UmSceneManager.AddDestroyObjectQueue(_newObject.get());
-    if (EditorHierarchyTool::HierarchyFocusObjWeak.lock() == _newObject)
+    if (EditorHierarchyTool::GetFocusObject().lock() == _newObject)
     {
         std::weak_ptr<GameObject> empty;
-        EditorHierarchyTool::HierarchyFocusObjWeak = empty;
+        EditorHierarchyTool::SetFocusObject(empty);
     }
     if (EditorInspectorTool::GetFocusObject().lock() == _newObject)
     {
@@ -226,10 +226,10 @@ void Command::EditorScene::DuplicateCommand::Undo()
     int instanceID = rootObject->GetInstanceID();
     rootObject->ActiveSelf = false;
     UmSceneManager.AddDestroyObjectQueue(rootObject.get());
-    if (EditorHierarchyTool::HierarchyFocusObjWeak.lock() == rootObject)
+    if (EditorHierarchyTool::GetFocusObject().lock() == rootObject)
     {
         std::weak_ptr<GameObject> empty;
-        EditorHierarchyTool::HierarchyFocusObjWeak = empty;
+        EditorHierarchyTool::SetFocusObject(empty);
     }
     if (EditorInspectorTool::GetFocusObject().lock() == rootObject)
     {

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -491,9 +491,9 @@ void EditorSceneTool::DrawSceneView()
 
 void EditorSceneTool::SetCameraToFocusObject() 
 {
-    if (false == EditorHierarchyTool::HierarchyFocusObjWeak.expired())
+    if (false == EditorHierarchyTool::GetFocusObject().expired())
     {
-        auto focusObject = EditorHierarchyTool::HierarchyFocusObjWeak.lock();
+        auto focusObject = EditorHierarchyTool::GetFocusObject().lock();
         _camera->SetPosition(focusObject->transform->Position);
     }
 }
@@ -547,7 +547,7 @@ void EditorSceneTool::RayPicker()
                                 intersects = obbWorld.Intersects(rayPos, rayDir, dist);
                                 if (true == intersects)
                                 {
-                                    std::weak_ptr old = EditorHierarchyTool::HierarchyFocusObjWeak;
+                                    std::weak_ptr old = EditorHierarchyTool::GetFocusObject();
                                     UmCommandManager.Do<Command::Hierarchy::FocusCommand>(
                                         old, meshComponent->gameObject->GetWeakPtr());
                                     break;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/EditorModule.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EditorCore/EditorModule.cpp
@@ -236,6 +236,8 @@ void EditorModule::EditorPlayMode::Play()
 {
     if (false == _isPlay)
     {
+        UmCommandManager.Clear();
+
         Scene* scene = UmSceneManager.GetMainScene();
         if (nullptr != scene)
         {
@@ -282,6 +284,8 @@ void EditorModule::EditorPlayMode::Stop()
 {
     if (true == _isPlay)
     {
+        UmCommandManager.Clear();
+
         for (const auto& object : ESceneManager::Engine::GetRuntimeObjects())
         {
             if (object)

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
@@ -1595,28 +1595,44 @@ void ESceneManager::InputSystem::UpdateInput()
         try
         {
             _inputController.UpdateState();
+            const auto& queue = _inputController.GetButtonQueue();
+            if (false == queue.empty())
+            {
+                for (const auto& flag : queue)
+                {
+                    UpdateTracker(flag);
+                }
+            }
+
             for (int buttonIndex = 0; buttonIndex < _receivers.size(); ++buttonIndex)
             {
                 auto& buttons = _receivers[buttonIndex];
-                //const auto& queue = _inputController.GetButtonQueue();
-                //for (const auto& button : queue)
-                //{
-                //    // ...
-                //}
-                UpdateTracker(buttonIndex);
                 for (int actionIndex = 0; actionIndex < buttons.size(); ++actionIndex)
                 {
                     Action action  = (Action)actionIndex;
                     auto&  actions = buttons[actionIndex];
                     for (auto& [component, event] : actions)
                     {
-                        if (action == _actionTracker[buttonIndex])
+                        Action& actionTracker = _actionTracker[buttonIndex];
+                        if (action == actionTracker)
                         {
-                            event(_inputController);
+                            event(_inputController);                       
                         }
+
+                        switch (actionTracker)
+                        {
+                        case Action::PRESSED:
+                            actionTracker = Action::HELD;
+                            break;
+                        case Action::RELEASED:
+                            actionTracker = Action::IDLE;
+                        default:
+                            break;
+                        }
+
                     }
                 }
-            }       
+            }
         }
         catch (const Input::DeviceNotConnectedException& exception)
         {
@@ -1631,68 +1647,50 @@ void ESceneManager::InputSystem::UpdateInput()
             throw;
 #endif
         }
+
     }
 }
 
-void ESceneManager::InputSystem::UpdateTracker(int index) 
+void ESceneManager::InputSystem::UpdateTracker(Input::Controller::Button button)
 {
-    ControllerButton button = (ControllerButton)index;
-    bool             isDown = false;
+    int index = std::countr_zero((unsigned int)button); 
+    Action& action = _actionTracker[index];
+    bool    isDown = false;
+
     switch (button)
     {
-    case ESceneManager::InputSystem::ControllerButton::A:
-        isDown = _inputController.IsButtonDown(Input::Controller::A);     
+    case Input::Controller::DPAD_UP:
+    case Input::Controller::DPAD_DOWN:
+    case Input::Controller::DPAD_LEFT:
+    case Input::Controller::DPAD_RIGHT:
+    case Input::Controller::START:
+    case Input::Controller::BACK:
+    case Input::Controller::LEFT_THUMB_BUTTON:
+    case Input::Controller::RIGHT_THUMB_BUTTON:
+    case Input::Controller::LEFT_SHOULDER:
+    case Input::Controller::RIGHT_SHOULDER:
+    case Input::Controller::A:
+    case Input::Controller::B:
+    case Input::Controller::X:
+    case Input::Controller::Y:
+        isDown = _inputController.IsButtonDown(button);
         break;
-    case ESceneManager::InputSystem::ControllerButton::B:
-        isDown = _inputController.IsButtonDown(Input::Controller::B);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::X:
-        isDown = _inputController.IsButtonDown(Input::Controller::X);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::Y:
-        isDown = _inputController.IsButtonDown(Input::Controller::Y);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::LEFT_SHOULDER:
-        isDown = _inputController.IsButtonDown(Input::Controller::LEFT_SHOULDER);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::RIGHT_SHOULDER:
-        isDown = _inputController.IsButtonDown(Input::Controller::RIGHT_SHOULDER);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::DPAD_UP:
-        isDown = _inputController.IsButtonDown(Input::Controller::DPAD_UP);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::DPAD_DOWN:
-        isDown = _inputController.IsButtonDown(Input::Controller::DPAD_DOWN);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::DPAD_LEFT:
-        isDown = _inputController.IsButtonDown(Input::Controller::DPAD_LEFT);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::DPAD_RIGHT:
-        isDown = _inputController.IsButtonDown(Input::Controller::DPAD_RIGHT);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::START:
-        isDown = _inputController.IsButtonDown(Input::Controller::START);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::BACK:
-        isDown = _inputController.IsButtonDown(Input::Controller::BACK);     
-        break;
-    case ESceneManager::InputSystem::ControllerButton::LEFT_TRIGGER:
-        isDown = 0.f < _inputController.GetLeftTrigger();
-        break;
-    case ESceneManager::InputSystem::ControllerButton::RIGHT_TRIGGER:
-        isDown = 0.f < _inputController.GetRightTrigger();
-        break;
-    case ESceneManager::InputSystem::ControllerButton::LEFT_STICK:
+    case Input::Controller::LEFT_THUMB_STICK:
         isDown = 0.f < _inputController.GetLeftThumbStickAxis().Magnitude;
         break;
-    case ESceneManager::InputSystem::ControllerButton::RIGHT_STICK:
+    case Input::Controller::RIGHT_THUMB_STICK:
         isDown = 0.f < _inputController.GetRightThumbStickAxis().Magnitude;
+        break;
+    case Input::Controller::LEFT_TRIGGER:
+        isDown = 0.f < _inputController.GetLeftTrigger();
+        break;
+    case Input::Controller::RIGHT_TRIGGER:
+        isDown = 0.f < _inputController.GetRightTrigger();
         break;
     default:
         break;
     }
 
-    Action& action = _actionTracker[index];
     if (true == isDown)
     {
         switch (action)
@@ -1723,4 +1721,5 @@ void ESceneManager::InputSystem::UpdateTracker(int index)
             break;
         }
     }
+
 }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.h
@@ -465,23 +465,25 @@ public:
     public:
         enum class ControllerButton
         {
-            A,
-            B,
-            X,
-            Y,
-            LEFT_TRIGGER,
-            RIGHT_TRIGGER,
-            LEFT_SHOULDER, 
-            RIGHT_SHOULDER,
-            START,
-            BACK,
-            LEFT_STICK,
-            RIGHT_STICK,
             DPAD_UP,
             DPAD_DOWN,
             DPAD_LEFT,
             DPAD_RIGHT,
-            UNKNOWN,
+            START,
+            BACK,
+            LEFT_THUMB_BUTTON,
+            RIGHT_THUMB_BUTTON,
+            LEFT_SHOULDER,
+            RIGHT_SHOULDER,
+            LEFT_TRIGGER,
+            RIGHT_TRIGGER,
+            A,
+            B,
+            X,
+            Y,
+            LEFT_THUMB_STICK,
+            RIGHT_THUMB_STICK,
+            UNKNOWN
         };
 
         enum class Action
@@ -490,7 +492,7 @@ public:
             RELEASED, 
             HELD,
             PRESSED,
-            UNKNOWN,
+            UNKNOWN
         };
 
         void UpdateInput();
@@ -498,28 +500,6 @@ public:
     private:
         static constexpr size_t ACTION_COUNT = (size_t)Action::UNKNOWN;
         static constexpr size_t CONTROLLER_BUTTON_COUNT = (size_t)ControllerButton::UNKNOWN;
-        inline static constexpr Input::Controller::Button INPUT_CONTROLLER_BUTTONS[] = 
-        {
-            Input::Controller::DPAD_UP,
-            Input::Controller::DPAD_DOWN,
-            Input::Controller::DPAD_LEFT,
-            Input::Controller::DPAD_RIGHT,
-            Input::Controller::START,
-            Input::Controller::BACK,
-            Input::Controller::LEFT_THUMB_BUTTON,
-            Input::Controller::RIGHT_THUMB_BUTTON,
-            Input::Controller::LEFT_SHOULDER,
-            Input::Controller::RIGHT_SHOULDER,
-            Input::Controller::A,
-            Input::Controller::B,
-            Input::Controller::X,
-            Input::Controller::Y,
-            Input::Controller::LEFT_THUMB_STICK,
-            Input::Controller::RIGHT_THUMB_STICK,
-            Input::Controller::LEFT_TRIGGER,
-            Input::Controller::RIGHT_TRIGGER,
-        };
-        static constexpr size_t INPUT_CONTROLLER_BUTTON_COUNT = sizeof(INPUT_CONTROLLER_BUTTONS) / sizeof(Input::Controller::Button);
 
         Input::XInputAdapter                            _inputAdapter;
         Input::Controller                               _inputController{&_inputAdapter};
@@ -532,7 +512,7 @@ public:
             _receivers;
 
     private:
-        void UpdateTracker(int button);
+        void UpdateTracker(Input::Controller::Button button);
 
     };
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/InputCore/Adapter/Controller/XInput/XInputAdapter.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/InputCore/Adapter/Controller/XInput/XInputAdapter.cpp
@@ -74,9 +74,9 @@ namespace Input
                 return Controller::X;
             case VK_PAD_Y:
                 return Controller::Y;
-            case VK_PAD_RSHOULDER:
-                return Controller::LEFT_SHOULDER;
             case VK_PAD_LSHOULDER:
+                return Controller::LEFT_SHOULDER;
+            case VK_PAD_RSHOULDER:
                 return Controller::RIGHT_SHOULDER;
             case VK_PAD_LTRIGGER:
                 return Controller::LEFT_TRIGGER;
@@ -138,7 +138,7 @@ namespace Input
 
             if (result == ERROR_SUCCESS)
             {
-                if (xKeystroke.Flags & XINPUT_KEYSTROKE_KEYDOWN && xKeystroke.Flags & XINPUT_KEYSTROKE_KEYUP)
+                if (xKeystroke.Flags & XINPUT_KEYSTROKE_KEYDOWN || xKeystroke.Flags & XINPUT_KEYSTROKE_KEYUP)
                 queue.push_back(VirtualKeyToButton(xKeystroke.VirtualKey));
             }
             else if (result == ERROR_DEVICE_NOT_CONNECTED)

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/InputCore/Devices/Controller/Controller.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/InputCore/Devices/Controller/Controller.h
@@ -32,14 +32,14 @@ namespace Input
             RIGHT_THUMB_BUTTON = 0x00080,
             LEFT_SHOULDER      = 0x00100,
             RIGHT_SHOULDER     = 0x00200,
+            LEFT_TRIGGER       = 0x00400,
+            RIGHT_TRIGGER      = 0x00800,
             A                  = 0x01000,
             B                  = 0x02000,
             X                  = 0x04000,
             Y                  = 0x08000,
             LEFT_THUMB_STICK   = 0x10000,
             RIGHT_THUMB_STICK  = 0x20000,
-            LEFT_TRIGGER       = 0x40000,
-            RIGHT_TRIGGER      = 0x80000,
         };
 
         /// <summary>

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Mesh/MeshComponent.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Mesh/MeshComponent.cpp
@@ -30,7 +30,3 @@ void MeshComponent::MakeMeshRenderer(MeshRenderType renderType, const Matrix& wo
     }
 }
 
-void MeshComponent::OnDrawDebugSelected()
-{
-    Renderer->SetCustomDepth(PostProcess::OUTLINE);
-}

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Mesh/MeshComponent.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Mesh/MeshComponent.h
@@ -25,9 +25,6 @@ public:
     //meshRenderer 입니다. MakeMeshRenderer를 호출해야만 생성됩니다.
     const std::unique_ptr<MeshRenderer>& Renderer;
 
-public:
-    virtual void OnDrawDebugSelected() override;
-
 protected:
     REFLECT_FIELDS_BEGIN(Component)
     REFLECT_FIELDS_END(MeshComponent)

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Test/Input/InputTestComponent.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Test/Input/InputTestComponent.cpp
@@ -23,12 +23,14 @@ void InputTestComponent::Awake()
     BindInputAction(ControllerButton::DPAD_RIGHT, Action::PRESSED, this, &InputTestComponent::OnButton);
     BindInputAction(ControllerButton::DPAD_UP, Action::PRESSED, this, &InputTestComponent::OnButton);
     BindInputAction(ControllerButton::DPAD_DOWN, Action::PRESSED, this, &InputTestComponent::OnButton);
+    BindInputAction(ControllerButton::LEFT_THUMB_BUTTON, Action::PRESSED, this, &InputTestComponent::OnButton);
+    BindInputAction(ControllerButton::RIGHT_THUMB_BUTTON, Action::PRESSED, this, &InputTestComponent::OnButton);
 
     BindInputAction(ControllerButton::LEFT_TRIGGER, Action::HELD, this, &InputTestComponent::OnTrigger);
     BindInputAction(ControllerButton::RIGHT_TRIGGER, Action::HELD, this, &InputTestComponent::OnTrigger);
 
-    BindInputAction(ControllerButton::LEFT_STICK, Action::HELD, this, &InputTestComponent::OnThumbStick);
-    BindInputAction(ControllerButton::RIGHT_STICK, Action::HELD, this, &InputTestComponent::OnThumbStick);
+    BindInputAction(ControllerButton::LEFT_THUMB_STICK, Action::HELD, this, &InputTestComponent::OnThumbStick);
+    BindInputAction(ControllerButton::RIGHT_THUMB_STICK, Action::HELD, this, &InputTestComponent::OnThumbStick);
 }
 
 void InputTestComponent::Update() 


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- refactor/VG-28/scene_input_refactor

---

## 🛠️ 변경 사항
- Play / Stop 전환할때 터지는 버그 수정
- 포커스 오브젝트 null 접근하는 버그 수정
- RayPicker로 선택된 오브젝트의 하이러키 TreeNode가 펼쳐지는 기능 추가
- 하이러키 오브젝트 선택시 외각선 표시하는 기능 버그 수정
- Scene Input System 리팩토링 

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

