### PR TITLE
[FIX/VG-28] Scene RayPicker에서 카메라 기준 정렬 안하는 버그 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -527,35 +527,51 @@ void EditorSceneTool::RayPicker()
                 Vector3 rayDir = Vector3(rayMax) - Vector3(rayMin);
                 rayDir.Normalize();
 
-                auto& meshComponents = UmSceneManager.GetMeshComponents();
-                bool  intersects     = false;
-                for (auto& weakMesh : meshComponents)
+                const std::vector<std::weak_ptr<MeshComponent>>& meshWeakComponents = UmSceneManager.GetMeshComponents();
+                std::vector<std::shared_ptr<MeshComponent>> meshComponents;
+                meshComponents.reserve(meshWeakComponents.size());
+                for (auto& weakMesh : meshWeakComponents)
                 {
-                    if (auto meshComponent = weakMesh.lock())
+                    if (std::shared_ptr<MeshComponent> mesh = weakMesh.lock())
                     {
-                        if (meshComponent->Enable && meshComponent->gameObject->ActiveInHierarchy)
+                        meshComponents.push_back(mesh);
+                    }           
+                }
+
+                const Vector3& camPosition = _camera->GetPosition();
+                std::ranges::sort(meshComponents, 
+                    [&camPosition](const std::shared_ptr<MeshComponent>& a, const std::shared_ptr<MeshComponent>& b) 
+                    {
+                        float disA = Vector3::DistanceSquared(camPosition, a->transform->Position);
+                        float disB = Vector3::DistanceSquared(camPosition, b->transform->Position);
+                        return disA < disB;
+                    });
+
+                bool intersects = false;
+                for (auto& meshComponent : meshComponents)
+                {
+                    if (meshComponent->Enable && meshComponent->gameObject->ActiveInHierarchy)
+                    {
+                        auto& meshes = meshComponent->Renderer->GetModel()->GetMeshes();
+                        for (auto& baseMesh : meshes)
                         {
-                            auto& meshes = meshComponent->Renderer->GetModel()->GetMeshes();
-                            for (auto& baseMesh : meshes)
+                            const BoundingOrientedBox& obb = baseMesh->GetBoundingBox();
+                            BoundingOrientedBox        obbWorld;
+                            const Matrix& worldMatrix = meshComponent->gameObject->transform->GetWorldMatrix();
+                            obb.Transform(obbWorld, worldMatrix);
+
+                            float dist = 0.f;
+                            intersects = obbWorld.Intersects(rayPos, rayDir, dist);
+                            if (true == intersects)
                             {
-                                const BoundingOrientedBox& obb = baseMesh->GetBoundingBox();
-                                BoundingOrientedBox        obbWorld;
-                                const Matrix& worldMatrix = meshComponent->gameObject->transform->GetWorldMatrix();
-                                obb.Transform(obbWorld, worldMatrix);
-
-                                float dist = 0.f;
-                                intersects = obbWorld.Intersects(rayPos, rayDir, dist);
-                                if (true == intersects)
-                                {
-                                    std::weak_ptr old = EditorHierarchyTool::GetFocusObject();
-                                    UmCommandManager.Do<Command::Hierarchy::FocusCommand>(
-                                        old, meshComponent->gameObject->GetWeakPtr());
-                                    break;
-                                }
+                                std::weak_ptr old = EditorHierarchyTool::GetFocusObject();
+                                UmCommandManager.Do<Command::Hierarchy::FocusCommand>(
+                                    old, meshComponent->gameObject->GetWeakPtr());
+                                break;
                             }
-                        }                       
-                    }
-
+                        }
+                    }                       
+                    
                     if (true == intersects)
                     {
                         break;


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-28/scene_view_editor_sort_fix

---

## 🛠️ 변경 사항
- 씬 뷰어에서 클릭해서 오브젝트 선택할때 카메라 기준 가까운것 먼저 선택 안하는 버그 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---
