### PR TITLE
[FEATURE/VG-29] 에디터 버그 및 편의성 개선

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.cpp
@@ -7,6 +7,13 @@ EditorDynamicCamera::EditorDynamicCamera()
     _rotationSpeed(5.f), 
     _pivot(0.f),
     _isManipulated(false),
+    _isMoved(false),
+    _isRotated(false),
+    _camera(nullptr),
+    _position(Vector3::Zero),
+    _rotation(Quaternion::Identity),
+    _pivotPosition(Vector3::Zero),
+
     _minmaxMoveSpeed(0.1f, 1000.f),
     _minmaxRotationSpeed(0.1f, 50.f)
 {}
@@ -18,6 +25,10 @@ void EditorDynamicCamera::SetTarget(std::shared_ptr<Camera> camera)
 
 void EditorDynamicCamera::Update()
 {
+    _isMoved = false;
+    _isRotated = false;
+    _isManipulated = false;
+
     ImGuiIO&      io           = ImGui::GetIO();
     const Vector3 forward      = Vector3::Transform(Vector3(0.0f, 0.0f, 1.0f), _rotation);
     bool          isLeftAlt    = ImGui::IsKeyDown(ImGuiKey_LeftAlt);
@@ -26,15 +37,15 @@ void EditorDynamicCamera::Update()
 
     if (isRightClick)
     {
-        _isManipulated = UpdateMove();
-        _isManipulated |= UpdateRotate();
+        _isMoved = UpdateMove();
+        _isRotated     = UpdateRotate();
         _pivotPosition = _position - forward * _pivot;
     }
     else
     {
         if (isLeftAlt && isLeftClick)
         {
-            _isManipulated = UpdateRotate();
+            _isRotated = UpdateRotate();
         }
 
         if (ImGui::IsKeyDown(ImGuiKey::ImGuiKey_MouseWheelY))
@@ -42,12 +53,14 @@ void EditorDynamicCamera::Update()
             float wheel = io.MouseWheel;
             _pivot += wheel * _moveSpeed * 0.2f;
             _pivot = std::min(_pivot, 0.f);
-            _isManipulated = true;
+            _isMoved = true;
         }
         _position = _pivotPosition + forward * _pivot;
     }
     _camera->SetPosition(_position);
     _camera->SetRotation(_rotation);
+
+    _isManipulated = _isMoved || _isRotated;
 }
 
 bool EditorDynamicCamera::UpdateMove()

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.cpp
@@ -4,9 +4,11 @@
 EditorDynamicCamera::EditorDynamicCamera() 
     : 
     _moveSpeed(10.f),
-    _moveScale(1.f),
     _rotationSpeed(5.f), 
-    _pivot(0.f)
+    _pivot(0.f),
+    _isManipulated(false),
+    _minmaxMoveSpeed(0.1f, 1000.f),
+    _minmaxRotationSpeed(0.1f, 50.f)
 {}
 
 void EditorDynamicCamera::SetTarget(std::shared_ptr<Camera> camera)
@@ -16,36 +18,31 @@ void EditorDynamicCamera::SetTarget(std::shared_ptr<Camera> camera)
 
 void EditorDynamicCamera::Update()
 {
-    ImGuiIO& io = ImGui::GetIO();
-    const Vector3 forward = Vector3::Transform(Vector3(0.0f, 0.0f, 1.0f), _rotation);
-    bool isLeftAlt = ImGui::IsKeyDown(ImGuiKey_LeftAlt);
-    bool isRightClick = ImGui::IsKeyDown(ImGuiKey_MouseRight);
-    bool isLeftClick = ImGui::IsKeyDown(ImGuiKey_MouseLeft);
+    ImGuiIO&      io           = ImGui::GetIO();
+    const Vector3 forward      = Vector3::Transform(Vector3(0.0f, 0.0f, 1.0f), _rotation);
+    bool          isLeftAlt    = ImGui::IsKeyDown(ImGuiKey_LeftAlt);
+    bool          isRightClick = ImGui::IsKeyDown(ImGuiKey_MouseRight);
+    bool          isLeftClick  = ImGui::IsKeyDown(ImGuiKey_MouseLeft);
 
     if (isRightClick)
     {
-        UpdateMove();
-        UpdateRotate();
-        if (ImGui::IsKeyDown(ImGuiKey::ImGuiKey_MouseWheelY))
-        {
-            float wheel = io.MouseWheel;
-            _moveScale += wheel * 0.05f;
-            _moveScale = std::clamp(_moveScale, 0.1f, 1000.f);
-        }
+        _isManipulated = UpdateMove();
+        _isManipulated |= UpdateRotate();
         _pivotPosition = _position - forward * _pivot;
     }
     else
     {
         if (isLeftAlt && isLeftClick)
         {
-            UpdateRotate();
+            _isManipulated = UpdateRotate();
         }
 
         if (ImGui::IsKeyDown(ImGuiKey::ImGuiKey_MouseWheelY))
         {
             float wheel = io.MouseWheel;
-            _pivot += wheel;
+            _pivot += wheel * _moveSpeed * 0.2f;
             _pivot = std::min(_pivot, 0.f);
+            _isManipulated = true;
         }
         _position = _pivotPosition + forward * _pivot;
     }
@@ -53,10 +50,11 @@ void EditorDynamicCamera::Update()
     _camera->SetRotation(_rotation);
 }
 
-void EditorDynamicCamera::UpdateMove() 
+bool EditorDynamicCamera::UpdateMove()
 {
+    bool  isMoved = false;
     const float deltaTime = UmTime.UnscaledDeltaTime();
-    float moveSpeed = _moveScale * _moveSpeed * deltaTime;
+    float moveSpeed = _moveSpeed * deltaTime;
     const Matrix& matrix = _camera->GetWorldMatrix();
     const Vector3 foward = -matrix.Forward();
     const Vector3 right  = -matrix.Right();
@@ -64,34 +62,43 @@ void EditorDynamicCamera::UpdateMove()
 
     if (ImGui::IsKeyDown(ImGuiKey::ImGuiKey_W))
     {
-        _position += foward * moveSpeed;
+        _position += foward * moveSpeed; 
+        isMoved = true;
     }
     if (ImGui::IsKeyDown(ImGuiKey::ImGuiKey_S))
     {
-        _position += -foward * moveSpeed;
+        _position += -foward * moveSpeed; 
+        isMoved = true;
     }
 
     if (ImGui::IsKeyDown(ImGuiKey::ImGuiKey_A))
     {
-        _position += right * moveSpeed;
+        _position += right * moveSpeed; 
+        isMoved = true;
     }
     if (ImGui::IsKeyDown(ImGuiKey::ImGuiKey_D))
     {
         _position += -right * moveSpeed;
+        isMoved = true;
     }
 
     if (ImGui::IsKeyDown(ImGuiKey::ImGuiKey_Q))
     {
         _position += -Vector3::Up * moveSpeed;
+        isMoved = true;
     }
     if (ImGui::IsKeyDown(ImGuiKey::ImGuiKey_E))
     {
         _position += Vector3::Up * moveSpeed;
+        isMoved = true;
     }
+
+    return isMoved;
 }
 
-void EditorDynamicCamera::UpdateRotate() 
+bool EditorDynamicCamera::UpdateRotate() 
 {
+    bool isMoved = false;
     ImGuiIO& io = ImGui::GetIO();
     ImVec2 mouseDelta = io.MouseDelta;
     if (mouseDelta.x != 0.f || mouseDelta.y != 0.f)
@@ -101,5 +108,7 @@ void EditorDynamicCamera::UpdateRotate()
         float deltaY = mouseDelta.y * rotateSpeed;
         _rotation *= Quaternion::CreateFromAxisAngle(Vector3::Up, deltaX);
         _rotation = Quaternion::CreateFromAxisAngle(Vector3::Right, deltaY) * _rotation;
+        isMoved   = true;
     }
+    return isMoved;
 }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.cpp
@@ -17,7 +17,6 @@ void EditorDynamicCamera::SetTarget(std::shared_ptr<Camera> camera)
 void EditorDynamicCamera::Update()
 {
     ImGuiIO& io = ImGui::GetIO();
-    const Matrix& matrix = _camera->GetWorldMatrix();
     const Vector3 forward = Vector3::Transform(Vector3(0.0f, 0.0f, 1.0f), _rotation);
     bool isLeftAlt = ImGui::IsKeyDown(ImGuiKey_LeftAlt);
     bool isRightClick = ImGui::IsKeyDown(ImGuiKey_MouseRight);

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.h
@@ -12,9 +12,9 @@ public:
 
 public:
     void SetTarget(std::shared_ptr<Camera> camera);
-    void SetMoveSpeed(const float speed) { _moveSpeed = std::clamp(speed, _minmaxMoveSpeed.first, _minmaxMoveSpeed.second);; }
+    void SetMoveSpeed(const float speed) { _moveSpeed = std::clamp(speed, _minmaxMoveSpeed.first, _minmaxMoveSpeed.second); }
     float GetMoveSpeed() const { return _moveSpeed; }
-    void SetRotationSpeed(const float speed) { _rotationSpeed = std::clamp(speed, _minmaxRotationSpeed.first, _minmaxRotationSpeed.second);; }
+    void SetRotationSpeed(const float speed) { _rotationSpeed = std::clamp(speed, _minmaxRotationSpeed.first, _minmaxRotationSpeed.second); }
     float GetRotationSpeed() const { return _rotationSpeed; }
 
     void SetPosition(const Vector3& position) {  _position = position;  _pivotPosition = position; }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.h
@@ -30,6 +30,8 @@ public:
     float GetPivot() const { return _pivot; }
 
     bool IsManipulated() const { return _isManipulated; }
+    bool IsMoved() const { return _isMoved; }
+    bool IsRotated() const { return _isRotated; }
 
     void SetMinMoveSpeed(float min) { _minmaxMoveSpeed.first = min; }  
     void SetMinRotationSpeed(float min) { _minmaxRotationSpeed.first = min; }
@@ -61,5 +63,7 @@ private:
     Vector3                 _pivotPosition;
     float                   _pivot;
 
+    bool                    _isMoved;
+    bool                    _isRotated;
     bool                    _isManipulated;
 };

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.h
@@ -17,11 +17,9 @@ public:
     void SetRotationSpeed(const float speed) { _rotationSpeed = speed; }
     float GetRotationSpeed() const { return _rotationSpeed; }
 
-    void SetPosition(const Vector3& position) 
-    { 
-        _position = position; 
-        _pivotPosition = position;
-    }
+   
+    void SetPosition(const Vector3& position) {  _position = position;  _pivotPosition = position; }
+    void SetPivotPosition(const Vector3& position) { _pivotPosition = position; }
     const Vector3& GetPosition() { return _position; }
     const Vector3& GetPivotPosition() { return _pivotPosition; }
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/DynamicCamera/EditorDynamicCamera.h
@@ -12,12 +12,11 @@ public:
 
 public:
     void SetTarget(std::shared_ptr<Camera> camera);
-    void SetMoveSpeed(const float speed) { _moveSpeed = speed; }
+    void SetMoveSpeed(const float speed) { _moveSpeed = std::clamp(speed, _minmaxMoveSpeed.first, _minmaxMoveSpeed.second);; }
     float GetMoveSpeed() const { return _moveSpeed; }
-    void SetRotationSpeed(const float speed) { _rotationSpeed = speed; }
+    void SetRotationSpeed(const float speed) { _rotationSpeed = std::clamp(speed, _minmaxRotationSpeed.first, _minmaxRotationSpeed.second);; }
     float GetRotationSpeed() const { return _rotationSpeed; }
 
-   
     void SetPosition(const Vector3& position) {  _position = position;  _pivotPosition = position; }
     void SetPivotPosition(const Vector3& position) { _pivotPosition = position; }
     const Vector3& GetPosition() { return _position; }
@@ -30,24 +29,37 @@ public:
     void SetPivot(float value) { _pivot = value; }
     float GetPivot() const { return _pivot; }
 
-    void SetMoveScale(float value) { _moveScale = std::clamp(value, 0.1f, 1000.f); }
-    float GetMoveScale() const { return _moveScale; }
+    bool IsManipulated() const { return _isManipulated; }
+
+    void SetMinMoveSpeed(float min) { _minmaxMoveSpeed.first = min; }  
+    void SetMinRotationSpeed(float min) { _minmaxRotationSpeed.first = min; }
+    void SetMaxMoveSpeed(float max) { _minmaxMoveSpeed.second = max; }
+    void SetMaxRotationSpeed(float max) { _minmaxRotationSpeed.second = max; }
+    float GetMinMoveSpeed() const { return _minmaxMoveSpeed.first; }
+    float GetMinRotationSpeed() const { return _minmaxRotationSpeed.first; }
+    float GetMaxMoveSpeed() const { return _minmaxMoveSpeed.second; }
+    float GetMaxRotationSpeed() const { return _minmaxRotationSpeed.second; }
 
 public:
     void Update();
 
 private:
-    void UpdateMove();
-    void UpdateRotate();
+    // 움직인 경우 true, 움직이지 않은 경우 false
+    bool UpdateMove();
+    // 회전한 경우 true, 회전하지 않은 경우 false
+    bool UpdateRotate();
 
 private:
     std::shared_ptr<Camera> _camera;
     Vector3                 _position;
     Quaternion              _rotation;
+    std::pair<float, float> _minmaxMoveSpeed;
     float                   _moveSpeed;
-    float                   _moveScale;
+    std::pair<float, float> _minmaxRotationSpeed;
     float                   _rotationSpeed;
 
     Vector3                 _pivotPosition;
     float                   _pivot;
+
+    bool                    _isManipulated;
 };

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.cpp
@@ -57,12 +57,13 @@ void EditorCommandTool::OnFrameRender()
     }
     ImGui::Separator();
 
-    int         total = 0;
-    int         curr  = 0;
+    _prevCommandStackSize = _currCommandStackSize;
+    size_t total = 0;
+    size_t curr  = 0;
     std::string icon  = EditorIcon::UnicodeToUTF8(0xf044);
 
     ImGuiChildFlags flags = ImGuiChildFlags_Border;
-    ImGui::BeginChild("FolderHierarchyFrame", ImVec2(0, 0), flags);
+    ImGui::BeginChild("##CommandToolChildFrame", ImVec2(0, 0), flags);
     {
         auto undoBegin = manager.UndoStackBegin();
         auto undoEnd   = manager.UndoStackEnd();
@@ -80,7 +81,7 @@ void EditorCommandTool::OnFrameRender()
                 ImGui::PushID(command.get());
                 if (ImGui::Selectable(name.c_str(), true))
                 {
-                    int queueSize     = manager.GetUndoStackSize();
+                    size_t queueSize  = manager.GetUndoStackSize();
                     _requestUndoCount = queueSize - curr;
                 }
                 ImGui::PopID();
@@ -115,6 +116,12 @@ void EditorCommandTool::OnFrameRender()
                 ImGui::PopID();
                 ImGui::PopStyleColor(2);
             }
+        }
+        // 커맨드가 갱신되었으면 스크롤을 내린다.
+        _currCommandStackSize = total;
+        if (_currCommandStackSize != _prevCommandStackSize)
+        {
+            ImGui::SetScrollHereY(1.0f);
         }
     }
     ImGui::EndChild();

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.cpp
@@ -139,7 +139,7 @@ void EditorCommandTool::OnFrameFocusExit() {}
 
 void EditorCommandTool::OnFramePopupOpened() {}
 
-ImVec4 EditorCommandTool::GetSelectableColor(int index, ImVec4 color)
+ImVec4 EditorCommandTool::GetSelectableColor(size_t index, ImVec4 color)
 {
     // 빼거나 더할 값
     ImVec4 blend = ImVec4(0.1f, 0.1f, 0.1f, 0.0f);

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.h
@@ -40,6 +40,9 @@ private:
     int _requestUndoCount = 0;
     int _requestRedoCount  = 0;
 
+    size_t _prevCommandStackSize = 0;
+    size_t _currCommandStackSize = 0;
+
     ImVec4 _tableDefaultColor = ImVec4(0.4f, 0.4f, 0.4f, 0.8f);
     ImVec4 _tableHoveredColor = ImVec4(0.6f, 0.6f, 0.6f, 0.8f);
     

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Command/EditorCommandTool.h
@@ -34,11 +34,11 @@ private:
     virtual void OnFramePopupOpened();
 
 private:
-    ImVec4 GetSelectableColor(int index, ImVec4 color);
+    ImVec4 GetSelectableColor(size_t index, ImVec4 color);
 
 private:
-    int _requestUndoCount = 0;
-    int _requestRedoCount  = 0;
+    size_t _requestUndoCount = 0;
+    size_t _requestRedoCount  = 0;
 
     size_t _prevCommandStackSize = 0;
     size_t _currCommandStackSize = 0;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Debug/EditorDebugTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Debug/EditorDebugTool.cpp
@@ -36,6 +36,8 @@ void EditorDebugTool::OnPostFrameBegin()
 
 void EditorDebugTool::OnFrameRender()
 {
+    const ImGuiIO& io = ImGui::GetIO();
+
     ImGui::InputDouble("Time scale", &engineCore->Time.TimeScale);
 
     ImGui::Text("Time : %f", engineCore->Time.Time());
@@ -55,6 +57,8 @@ void EditorDebugTool::OnFrameRender()
     ImGui::Text("FixedUnscaledDeltaTime %f", engineCore->Time.FixedUnscaledDeltaTime());
 
     ImGui::InputDouble("maximumDeltaTime", &engineCore->Time.MaximumDeltaTime);
+
+    ImGui::Text("Mouse Delta: (%.3f, %.3f)", io.MouseDelta.x, io.MouseDelta.y);
 }
 
 void EditorDebugTool::OnFrameEnd()

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/Command/DetachChildrenCommand.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/Command/DetachChildrenCommand.cpp
@@ -22,8 +22,8 @@ bool Command::Hierarchy::DetachChildrenCommand::Execute()
             }
             targetObject->transform->DetachChildren();
             targetObject->GetScene().IsDirty = true;
+            return true;
         }
-        return true;
     }
     return false;
 }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/Command/FocusCommand.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/Command/FocusCommand.cpp
@@ -3,10 +3,15 @@
 Command::Hierarchy::FocusCommand::~FocusCommand() = default;
 bool Command::Hierarchy::FocusCommand::Execute()
 {
+    bool isFocused = EditorInspectorTool::IsFocusObject(_newFocused);
+    // 이미 포커스된 오브젝트라면 아무것도 하지 않음
+    if (true == isFocused)
+    {   
+        return false;
+    }
     Super::Execute();
     EditorHierarchyTool::SetFocusObject(_newFocused);
     EditorSceneTool::SetManipulateObject(_newFocused);
-
     return true;
 }
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -16,11 +16,28 @@ static EditorSceneTool* staticEditorScenTool = nullptr;
 
 void EditorHierarchyTool::TransformTreeNode(Transform& node, const std::shared_ptr<GameObject>& focusObject,  GameObject*& outClickNode)
 {
-    auto TreeClickEvent = [&node, &outClickNode]() {
-        bool result = ImGui::IsMouseReleased(ImGuiMouseButton_Left) && ImGui::IsItemHovered();
-        if (result)
+    EditorSceneTool* sceneTool = _editorSceneTool;
+    auto TreeClickEvent = [&node, &outClickNode, &sceneTool]() {
+        bool isHovered = ImGui::IsItemHovered();
+        bool isDoubleClicked = ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left);
+        bool isReleased      = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
+
+        bool result = false;
+        if (isHovered)
         {
-            outClickNode = &node.gameObject;
+            if (isDoubleClicked)
+            {
+                if (sceneTool)
+                {
+                    sceneTool->SetCameraToObject(node.gameObject->GetWeakPtr());
+                }
+                result = true;
+            }
+            else if (isReleased)
+            {
+                outClickNode = &node.gameObject;
+                result = true;
+            }
         }
         return result;
     };

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -442,6 +442,7 @@ void EditorHierarchyTool::HierarchyDropEvent()
     ImRect rect = _window->Rect();
     if (ImGui::BeginDragDropTargetCustom(rect, _window->ID))
     {
+        // 에셋에 대한 드래그 앤 드롭 이벤트 처리
         if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(DragDropAsset::KEY))
         {
             DragDropAsset::Data* data = (DragDropAsset::Data*)payload->Data;      
@@ -459,6 +460,27 @@ void EditorHierarchyTool::HierarchyDropEvent()
                 {
                     UmSceneManager.LoadScene(path.string(), LoadSceneMode::ADDITIVE);
                 }
+            }
+        }
+        // Transform에 대한 드래그 앤 드롭 이벤트 처리
+        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(DragDropTransform::KEY))
+        {
+            DragDropTransform::Data* data = (DragDropTransform::Data*)payload->Data;
+            // 데이터 Null 확인
+            if (data && data->pTransform)
+            {
+                // 1. Hierarchy 프레임에 드롭한 것은 Root로 설정하겠다는 것
+                Transform* current = data->pTransform;
+                Transform* parent  = data->pTransform->Parent;
+                // 때문에 부모가 없으면 커맨드를 실행할 필요가 없음.
+                if (current && parent)
+                {
+                    std::weak_ptr<GameObject> currentWeak, parentWeak;
+                    currentWeak = current->gameObject->GetWeakPtr();
+                    parentWeak  = parent->gameObject->GetWeakPtr();
+                    UmCommandManager.Do<Command::Hierarchy::SetParentCommand>(currentWeak, parentWeak, nullptr);
+                }
+                
             }
         }
         ImGui::EndDragDropTarget();

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -66,15 +66,18 @@ void EditorHierarchyTool::TransformTreeNode(Transform& node, const std::shared_p
                 Transform* prevParent = data->pTransform->Parent;
                 auto targetObject = data->pTransform->gameObject->GetWeakPtr();
                 auto currObject   = node.gameObject->GetWeakPtr();
-                if (nullptr != prevParent)
+                if (prevParent != data->pTransform)
                 {
-                    auto prevObject = prevParent->gameObject->GetWeakPtr();
-                    UmCommandManager.Do<Command::Hierarchy::SetParentCommand>(targetObject, prevObject, currObject);
-                }
-                else
-                {
-                    UmCommandManager.Do<Command::Hierarchy::SetParentCommand>(targetObject, nullptr, currObject);
-                }            
+                    if (nullptr != prevParent)
+                    {
+                        auto prevObject = prevParent->gameObject->GetWeakPtr();
+                        UmCommandManager.Do<Command::Hierarchy::SetParentCommand>(targetObject, prevObject, currObject);
+                    }
+                    else
+                    {
+                        UmCommandManager.Do<Command::Hierarchy::SetParentCommand>(targetObject, nullptr, currObject);
+                    }  
+                } 
             }
             ImGui::EndDragDropTarget();
         }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Inspector/EditorInspectorTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Inspector/EditorInspectorTool.cpp
@@ -95,6 +95,14 @@ bool EditorInspectorTool::SetFocusObject(std::weak_ptr<IEditorObject> obj)
     return false;
 }
 
+void EditorInspectorTool::ResetFocusObject() 
+{
+    _nextFocused = std::weak_ptr<IEditorObject>();
+    _isFocusChanged = true;
+    EditorHierarchyTool::SetFocusObject(std::weak_ptr<GameObject>()); // HierarchyTool의 포커스도 초기화
+    EditorSceneTool::SetManipulateObject(std::weak_ptr<GameObject>()); // SceneTool의 조작 오브젝트도 초기화
+}
+
 std::weak_ptr<IEditorObject> EditorInspectorTool::GetFocusObject()
 {
     return _currFocused;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Inspector/EditorInspectorTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Inspector/EditorInspectorTool.h
@@ -23,6 +23,7 @@ public:
 
     static bool IsFocusObject(std::weak_ptr<IEditorObject> obj);
     static bool SetFocusObject(std::weak_ptr<IEditorObject> obj);
+    static void ResetFocusObject();
     static std::weak_ptr<IEditorObject> GetFocusObject();
 
 private:

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Model/EditorModelDetails.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Model/EditorModelDetails.cpp
@@ -162,13 +162,6 @@ void EditorModelDetails::OnFrameRender()
         if (_modelTool && _modelTool->GetCamera())
         {
             auto& camera = _modelTool->GetCamera();
-            // Speed
-            ImGui::Text("Camera Move Scale: ");
-            float moveScale = camera->GetMoveScale();
-            if (ImGui::SliderFloat("##camera move scale", &moveScale, 0.1f, 1000.f))
-            {
-                camera->SetMoveScale(moveScale);
-            }
             ImGui::Text("Camera Move Speed: ");
             float moveSpeed = camera->GetMoveSpeed();
             if (ImGui::SliderFloat("##camera move speed", &moveSpeed, 0.1f, 100.f))

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Model/EditorModelTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Model/EditorModelTool.cpp
@@ -63,46 +63,39 @@ void EditorModelTool::OnFrameRender()
     ImGui::Image((ImTextureID)handle.ptr, size);
     if (ImGui::IsWindowHovered() || IsFocusFrame())
     {
-        ImGui::SetCursorScreenPos(pos);
-        float moveSpeed     = _camera->GetMoveSpeed();
-        float rotationSpeed = _camera->GetRotationSpeed();
-        int   pushCount     = 0;
-        if (ImGui::IsKeyDown(ImGuiKey_MouseRight))
-        {
-            ImGuiStyle& style   = ImGui::GetStyle();
-            ImVec4      bgCol   = style.Colors[ImGuiCol_FrameBg];
-            ImVec4      textCol = style.Colors[ImGuiCol_Text];
-            bgCol.w *= 0.5f;
-            textCol.w *= 0.5f;
-            ImGui::PushStyleColor(ImGuiCol_FrameBg, bgCol);
-            ImGui::PushStyleColor(ImGuiCol_Text, textCol);
-            ++pushCount;
-            ++pushCount;
-        }
-        ImGui::SetNextItemWidth(150.0f);
-        if (ImGui::SliderFloat("Camera Move Speed##camera move speed", &moveSpeed, 0.1f, 500.f, "%.2f",
-                               ImGuiSliderFlags_AlwaysClamp))
-        {
-        }
-        ImGui::SetNextItemWidth(150.0f);
-        if (ImGui::SliderFloat("Camera Rotation Speed##camera rotation speed", &rotationSpeed, 0.1f, 50.f, "%.2f",
-                               ImGuiSliderFlags_AlwaysClamp))
-        {
-        }
-        ImGui::PopStyleColor(pushCount);
-
-        // 우클릭 + 마우스 휠 시 카메라 이동속도 높이기
-        if (ImGui::IsKeyDown(ImGuiKey_MouseRight))
-        {
-            moveSpeed += ImGui::GetIO().MouseWheel * 2.0f;
-            moveSpeed = std::max(moveSpeed, 0.1f);
-        }
-
-        _camera->SetMoveSpeed(moveSpeed);
-        _camera->SetRotationSpeed(rotationSpeed);
-
         if (_camera)
         {
+            ImGui::SetCursorScreenPos(pos);
+            float moveSpeed     = _camera->GetMoveSpeed();
+            float rotationSpeed = _camera->GetRotationSpeed();
+            int   pushCount     = 0;
+            if (ImGui::IsKeyDown(ImGuiKey_MouseRight))
+            {
+                ImGuiStyle& style   = ImGui::GetStyle();
+                ImVec4      bgCol   = style.Colors[ImGuiCol_FrameBg];
+                ImVec4      textCol = style.Colors[ImGuiCol_Text];
+                bgCol.w *= 0.5f;
+                textCol.w *= 0.5f;
+                ImGui::PushStyleColor(ImGuiCol_FrameBg, bgCol);
+                ImGui::PushStyleColor(ImGuiCol_Text, textCol);
+                ++pushCount;
+                ++pushCount;
+            }
+            ImGui::SetNextItemWidth(150.0f);
+            int flags = ImGuiSliderFlags_AlwaysClamp;
+            ImGui::SliderFloat("Camera Move Speed##move speed", &moveSpeed, _camera->GetMinMoveSpeed(),
+                               _camera->GetMaxMoveSpeed(), "%.2f", flags);
+            ImGui::SetNextItemWidth(150.0f);
+            ImGui::SliderFloat("Camera Rotation Speed##rotation speed", &rotationSpeed, _camera->GetMinRotationSpeed(),
+                               _camera->GetMaxRotationSpeed(), "%.2f", flags);
+            ImGui::PopStyleColor(pushCount);
+            // 우클릭 + 마우스 휠 시 카메라 이동속도 높이기
+            if (ImGui::IsKeyDown(ImGuiKey_MouseRight))
+            {
+                moveSpeed *= 1.0f + (ImGui::GetIO().MouseWheel * 0.05f);
+            }
+            _camera->SetMoveSpeed(moveSpeed);
+            _camera->SetRotationSpeed(rotationSpeed);
             _camera->Update();
         }
     }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -240,7 +240,9 @@ void EditorSceneTool::DrawManipulate()
         auto pObject = _manipulateObject.lock();
         if (pObject->IsValid())
         {
+            const ImGuiIO& io    = ImGui::GetIO();
             bool isLeftShiftHold = ImGui::IsKeyDown(ImGuiKey::ImGuiKey_LeftShift);
+            bool isMouseMoved    = (io.MouseDelta.x != 0.0f || io.MouseDelta.y != 0.0f);
 
             Matrix  worldMatrix   = pObject->transform->GetWorldMatrix();
             Matrix* pObjectMatrix = &worldMatrix;
@@ -255,6 +257,12 @@ void EditorSceneTool::DrawManipulate()
             _isUseManipulate = ImGuiHelper::DrawManipulate(pDynamicCamera, pObjectMatrix, _drawManipulateDesc);
             _isUsing         = ImGuizmo::IsUsing();
             _isOver          = ImGuizmo::IsOver();
+
+            // 마우스를 움직인 경우에만 Moved 플래그 설정
+            if (true == _isUsing && true == isMouseMoved)
+            {
+                _isMovedManipulate = true;
+            }
 
             if (isLeftShiftHold)    
             {
@@ -297,19 +305,24 @@ void EditorSceneTool::DrawManipulate()
                 {
                     if (true == _isUsing)
                     {
-                        _isUsingStart          = true;
+                        _isUsingStart = true;
                         prevTransform.Position = pObject->transform->Position;
                         prevTransform.Rotation = pObject->transform->Rotation;
                         prevTransform.Scale    = pObject->transform->Scale;
                     }
                     else
                     {
+                        // 이동한 경우에만 커맨드를 실행
+                        if (true == _isMovedManipulate)
+                        {
+                            ManipulateCommand::Transform currTransform;
+                            currTransform.Position = pObject->transform->Position;
+                            currTransform.Rotation = pObject->transform->Rotation;
+                            currTransform.Scale    = pObject->transform->Scale;
+                            UmCommandManager.Do<ManipulateCommand>(pObject, currTransform, prevTransform);
+                            _isMovedManipulate = false;
+                        }
                         _isUsingEnd = true;
-                        ManipulateCommand::Transform currTransform;
-                        currTransform.Position = pObject->transform->Position;
-                        currTransform.Rotation = pObject->transform->Rotation;
-                        currTransform.Scale    = pObject->transform->Scale;
-                        UmCommandManager.Do<ManipulateCommand>(pObject, currTransform, prevTransform);
                     }
                 }
                 else

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -548,8 +548,8 @@ void EditorSceneTool::DrawSceneView()
         float moveSpeed     = _camera->GetMoveSpeed();
         float rotationSpeed = _camera->GetRotationSpeed();
         int   pushCount     = 0;
-        // 조작중인 경우 알파를 낮춤
-        if (_camera && true == _camera->IsManipulated())
+        // 움직인 경우에만 알파를 낮춤
+        if (_camera && true == _camera->IsMoved())
         {
             ImGuiStyle& style   = ImGui::GetStyle();
             ImVec4      bgCol   = style.Colors[ImGuiCol_FrameBg];

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -50,6 +50,44 @@ const Matrix& EditorSceneTool::GetCameraMatrix()
     return _camera->GetCamera()->GetWorldMatrix();
 }
 
+void EditorSceneTool::SetCameraToObject(std::weak_ptr<GameObject> destination) 
+{
+    if (false == destination.expired())
+    {
+        auto pObject = destination.lock();
+        if (pObject->IsValid() && _camera)
+        {
+            _isFocusedCamera = true;
+            _focusedCameraTargetPosition = pObject->transform->Position;
+            _focusedCameraStartPosition  = _camera->GetPivotPosition();
+            _camera->LookTo(_focusedCameraTargetPosition);
+        }
+    }
+}
+
+void EditorSceneTool::OnTickGui()
+{
+    if (_isFocusedCamera && _camera)
+    {
+        const float lerpT = _focusedLerpScale;
+        Vector3& current  = _focusedCameraStartPosition;
+        Vector3& target   = _focusedCameraTargetPosition;
+
+        current = ImLerp(current, target, lerpT);
+
+        // 거리가 충분히 가까워지면 카메라를 고정합니다.
+        Vector3 delta = target - current;
+        float   deltaLength = delta.Length();
+        if (deltaLength <= 1.0f)
+        {
+            current          = target;
+            _isFocusedCamera = false;
+        }
+        _camera->SetPivotPosition(current);
+        _camera->Update();
+    }
+}
+
 void EditorSceneTool::OnStartGui()
 {
     std::shared_ptr<Camera> camera = UmRenderer.GetCamera("Editor");
@@ -190,7 +228,8 @@ void EditorSceneTool::UpdateKeyboardShortcuts()
 
         if (ImGui::IsKeyPressed(ImGuiKey_F, false))
         {
-            SetCameraToFocusObject();
+            auto wPtrFocused = EditorHierarchyTool::GetFocusObject();
+            SetCameraToObject(wPtrFocused);
         }
     }  
 }
@@ -487,15 +526,6 @@ void EditorSceneTool::DrawSceneView()
         ImGui::SameLine();
     }
     ImageButtonToggleSetting();
-}
-
-void EditorSceneTool::SetCameraToFocusObject() 
-{
-    if (false == EditorHierarchyTool::GetFocusObject().expired())
-    {
-        auto focusObject = EditorHierarchyTool::GetFocusObject().lock();
-        _camera->SetPosition(focusObject->transform->Position);
-    }
 }
 
 void EditorSceneTool::RayPicker() 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -60,7 +60,6 @@ void EditorSceneTool::SetCameraToObject(std::weak_ptr<GameObject> destination)
             _isFocusedCamera = true;
             _focusedCameraTargetPosition = pObject->transform->Position;
             _focusedCameraStartPosition  = _camera->GetPivotPosition();
-            _camera->LookTo(_focusedCameraTargetPosition);
         }
     }
 }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -538,6 +538,50 @@ void EditorSceneTool::DrawSceneView()
         ImGui::SameLine();
     }
     ImageButtonToggleSetting();
+    if (_camera)
+    {
+        float moveSpeed     = _camera->GetMoveSpeed();
+        float rotationSpeed = _camera->GetRotationSpeed();
+        int   pushCount     = 0;
+        // 조작중인 경우 알파를 낮춤
+        if (_camera && true == _camera->IsManipulated())
+        {
+            ImGuiStyle& style   = ImGui::GetStyle();
+            ImVec4      bgCol   = style.Colors[ImGuiCol_FrameBg];
+            ImVec4      textCol = style.Colors[ImGuiCol_Text];
+            bgCol.w *= 0.3f;
+            textCol.w *= 0.3f;
+            ImGui::PushStyleColor(ImGuiCol_FrameBg, bgCol);
+            ++pushCount;
+            ImGui::PushStyleColor(ImGuiCol_Text, textCol);
+            ++pushCount;
+        }
+        ImGui::SetNextItemWidth(150.0f);
+        int flags = ImGuiSliderFlags_AlwaysClamp;
+        ImGui::SliderFloat("Camera Move Speed##move speed",
+            &moveSpeed,
+            _camera->GetMinMoveSpeed(), 
+            _camera->GetMaxMoveSpeed(), 
+            "%.2f", 
+            flags
+        );
+        ImGui::SetNextItemWidth(150.0f);
+        ImGui::SliderFloat("Camera Rotation Speed##rotation speed",
+            &rotationSpeed, 
+            _camera->GetMinRotationSpeed(),
+            _camera->GetMaxRotationSpeed(),
+            "%.2f",
+            flags
+        );
+        ImGui::PopStyleColor(pushCount);
+        // 우클릭 + 마우스 휠 시 카메라 이동속도 높이기
+        if (ImGui::IsKeyDown(ImGuiKey_MouseRight))
+        {
+            moveSpeed *= 1.0f + (ImGui::GetIO().MouseWheel * 0.05f);
+        }
+        _camera->SetMoveSpeed(moveSpeed);
+        _camera->SetRotationSpeed(rotationSpeed);
+    }
 }
 
 void EditorSceneTool::RayPicker() 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -40,7 +40,7 @@ EditorSceneTool::~EditorSceneTool()
 
 }
 
-void EditorSceneTool::SetManipulateObject(std::weak_ptr<GameObject>& object) 
+void EditorSceneTool::SetManipulateObject(const std::weak_ptr<GameObject>& object) 
 {
     pSceneTool->_manipulateObject = object;
 }
@@ -669,6 +669,10 @@ void EditorSceneTool::RayPicker()
                     {
                         break;
                     }
+                }
+                if (false == intersects)
+                {
+                    EditorInspectorTool::ResetFocusObject();
                 }
             }
         }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -202,39 +202,43 @@ void EditorSceneTool::SetCamera()
 
 void EditorSceneTool::UpdateKeyboardShortcuts()
 {
-    if (false == ImGui::IsKeyDown(ImGuiKey_MouseRight))
+    if (true == _isDrawedManipulate)
     {
-        if (ImGui::IsKeyPressed(ImGuiKey_W, false))
-            _drawManipulateDesc.Operation = ImGuizmo::TRANSLATE;
-        if (ImGui::IsKeyPressed(ImGuiKey_E, false))
-            _drawManipulateDesc.Operation = ImGuizmo::ROTATE;
-        if (ImGui::IsKeyPressed(ImGuiKey_R, false))
-            _drawManipulateDesc.Operation = ImGuizmo::SCALE;
-        if (ImGui::IsKeyPressed(ImGuiKey_T, false))
-            _drawManipulateDesc.Operation = ImGuizmo::UNIVERSAL;
-
-        if (ImGui::IsKeyPressed(ImGuiKey_X, false))
+        if (false == ImGui::IsKeyDown(ImGuiKey_MouseRight))
         {
-            if (_drawManipulateDesc.Mode == ImGuizmo::MODE::LOCAL)
-            {
-                _drawManipulateDesc.Mode = ImGuizmo::MODE::WORLD;
-            }
-            else
-            {
-                _drawManipulateDesc.Mode = ImGuizmo::MODE::LOCAL;
-            }
-        }      
+            if (ImGui::IsKeyPressed(ImGuiKey_W, false))
+                _drawManipulateDesc.Operation = ImGuizmo::TRANSLATE;
+            if (ImGui::IsKeyPressed(ImGuiKey_E, false))
+                _drawManipulateDesc.Operation = ImGuizmo::ROTATE;
+            if (ImGui::IsKeyPressed(ImGuiKey_R, false))
+                _drawManipulateDesc.Operation = ImGuizmo::SCALE;
+            if (ImGui::IsKeyPressed(ImGuiKey_T, false))
+                _drawManipulateDesc.Operation = ImGuizmo::UNIVERSAL;
 
-        if (ImGui::IsKeyPressed(ImGuiKey_F, false))
-        {
-            auto wPtrFocused = EditorHierarchyTool::GetFocusObject();
-            SetCameraToObject(wPtrFocused);
-        }
-    }  
+            if (ImGui::IsKeyPressed(ImGuiKey_X, false))
+            {
+                if (_drawManipulateDesc.Mode == ImGuizmo::MODE::LOCAL)
+                {
+                    _drawManipulateDesc.Mode = ImGuizmo::MODE::WORLD;
+                }
+                else
+                {
+                    _drawManipulateDesc.Mode = ImGuizmo::MODE::LOCAL;
+                }
+            }
+
+            if (ImGui::IsKeyPressed(ImGuiKey_F, false))
+            {
+                auto wPtrFocused = EditorHierarchyTool::GetFocusObject();
+                SetCameraToObject(wPtrFocused);
+            }
+        }  
+    }
 }
 
 void EditorSceneTool::DrawManipulate() 
 {
+    _isDrawedManipulate = false;
     if (false == _manipulateObject.expired())
     {
         auto pObject = _manipulateObject.lock();
@@ -339,9 +343,10 @@ void EditorSceneTool::DrawManipulate()
                         UmCommandManager.Do<Command::EditorScene::DuplicateCommand>(pObject.get());
                     }
                 }
+                _isDrawedManipulate = true;
             }
         }
-    }   
+    }
 }
 
 void EditorSceneTool::DrawSceneView() 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -122,6 +122,7 @@ void EditorSceneTool::OnFrameRender()
     DrawManipulate();
     RayPicker();
     VertexSnap();
+    UpdateKeyboardFrameRender();
 }
 
 void EditorSceneTool::OnFrameEnd()
@@ -131,7 +132,7 @@ void EditorSceneTool::OnFrameEnd()
 void EditorSceneTool::OnFrameFocusStay()
 {
     _camera->Update();
-    UpdateKeyboardShortcuts();
+    UpdateKeyboardFrameFocus();
 }
     
 void EditorSceneTool::DragDropEvent() 
@@ -200,7 +201,7 @@ void EditorSceneTool::SetCamera()
         ReflectFields->CameraFarZ);
 }
 
-void EditorSceneTool::UpdateKeyboardShortcuts()
+void EditorSceneTool::UpdateKeyboardFrameFocus()
 {
     if (true == _isDrawedManipulate)
     {
@@ -226,20 +227,26 @@ void EditorSceneTool::UpdateKeyboardShortcuts()
                     _drawManipulateDesc.Mode = ImGuizmo::MODE::LOCAL;
                 }
             }
-
-            if (ImGui::IsKeyPressed(ImGuiKey_F, false))
-            {
-                auto wPtrFocused = EditorHierarchyTool::GetFocusObject();
-                SetCameraToObject(wPtrFocused);
-            }
         }  
+    }
+}
+
+void EditorSceneTool::UpdateKeyboardFrameRender() 
+{
+    if (_isDrawedManipulate)
+    {
+        if (ImGui::IsKeyPressed(ImGuiKey_F, false))
+        {
+            auto wPtrFocused = EditorHierarchyTool::GetFocusObject();
+            SetCameraToObject(wPtrFocused);
+        }
     }
 }
 
 void EditorSceneTool::DrawManipulate() 
 {
-    _isDrawedManipulate = false;
-    if (false == _manipulateObject.expired())
+    _isDrawedManipulate = false == _manipulateObject.expired();
+    if (true == _isDrawedManipulate)
     {
         auto pObject = _manipulateObject.lock();
         if (pObject->IsValid())
@@ -343,7 +350,6 @@ void EditorSceneTool::DrawManipulate()
                         UmCommandManager.Do<Command::EditorScene::DuplicateCommand>(pObject.get());
                     }
                 }
-                _isDrawedManipulate = true;
             }
         }
     }
@@ -543,13 +549,13 @@ void EditorSceneTool::DrawSceneView()
         ImGui::SameLine();
     }
     ImageButtonToggleSetting();
-    if (_camera)
+    if (_camera && showSettings)
     {
         float moveSpeed     = _camera->GetMoveSpeed();
         float rotationSpeed = _camera->GetRotationSpeed();
         int   pushCount     = 0;
         // 움직인 경우에만 알파를 낮춤
-        if (_camera && true == _camera->IsMoved())
+        if (true == ImGui::IsKeyDown(ImGuiKey_MouseRight) && IsFocusFrame())
         {
             ImGuiStyle& style   = ImGui::GetStyle();
             ImVec4      bgCol   = style.Colors[ImGuiCol_FrameBg];
@@ -586,6 +592,7 @@ void EditorSceneTool::DrawSceneView()
         }
         _camera->SetMoveSpeed(moveSpeed);
         _camera->SetRotationSpeed(rotationSpeed);
+        UpdateReflectFields();
     }
 }
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.cpp
@@ -40,7 +40,7 @@ EditorSceneTool::~EditorSceneTool()
 
 }
 
-void EditorSceneTool::SetManipulateObject(const std::weak_ptr<GameObject>& object) 
+void EditorSceneTool::SetManipulateObject(std::weak_ptr<GameObject> object) 
 {
     pSceneTool->_manipulateObject = object;
 }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
@@ -67,6 +67,7 @@ private:
     std::weak_ptr<GameObject> _manipulateObject;
     ImGuiHelper::DrawManipulateDesc _drawManipulateDesc; 
     bool _isUseManipulate = false;
+    bool _isDrawedManipulate = false;
     bool _isMovedManipulate = false;
     bool _isUsingStart = false; 
     bool _isUsingEnd = false; 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
@@ -67,6 +67,7 @@ private:
     std::weak_ptr<GameObject> _manipulateObject;
     ImGuiHelper::DrawManipulateDesc _drawManipulateDesc; 
     bool _isUseManipulate = false;
+    bool _isMovedManipulate = false;
     bool _isUsingStart = false; 
     bool _isUsingEnd = false; 
     bool _isUsing = false;

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
@@ -12,7 +12,7 @@ public:
     EditorSceneTool();
     virtual ~EditorSceneTool();
 
-    static void SetManipulateObject(std::weak_ptr<GameObject>& object);
+    static void SetManipulateObject(const std::weak_ptr<GameObject>& object);
 
 public:
     const Matrix& GetCameraMatrix();

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
@@ -37,7 +37,8 @@ private:
     void OnFrameFocusStay() override;
 
 private:
-    void UpdateKeyboardShortcuts();
+    void UpdateKeyboardFrameFocus();
+    void UpdateKeyboardFrameRender();
     void DragDropEvent();
     void SetMoveFlag();
     void SetCamera();

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
@@ -12,7 +12,7 @@ public:
     EditorSceneTool();
     virtual ~EditorSceneTool();
 
-    static void SetManipulateObject(const std::weak_ptr<GameObject>& object);
+    static void SetManipulateObject(std::weak_ptr<GameObject> object);
 
 public:
     const Matrix& GetCameraMatrix();

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Scene/EditorSceneTool.h
@@ -16,22 +16,25 @@ public:
 
 public:
     const Matrix& GetCameraMatrix();
+    void SetCameraToObject(std::weak_ptr<GameObject> destination);
 
 private:
     inline static EditorSceneTool* pSceneTool = nullptr;
 
 private:
-    virtual void OnStartGui() override;
+    void OnTickGui() override;
 
-    virtual void OnPreFrameBegin() override;
+    void OnStartGui() override;
 
-    virtual void OnPostFrameBegin() override;
+    void OnPreFrameBegin() override;
 
-    virtual void OnFrameRender() override;
+    void OnPostFrameBegin() override;
 
-    virtual void OnFrameEnd() override;
+    void OnFrameRender() override;
 
-    virtual void OnFrameFocusStay() override;
+    void OnFrameEnd() override;
+
+    void OnFrameFocusStay() override;
 
 private:
     void UpdateKeyboardShortcuts();
@@ -40,7 +43,6 @@ private:
     void SetCamera();
     void DrawManipulate();
     void DrawSceneView();
-    void SetCameraToFocusObject();
     void RayPicker();
     void VertexSnap();
 
@@ -51,7 +53,6 @@ private:
     ImGuiWindow* _window = nullptr;
     EditorDockWindow* _dockWindow = nullptr;
     bool _isHorverdScene = false;
-
     std::unique_ptr<EditorDynamicCamera> _camera;
 
     //clientSize
@@ -76,6 +77,13 @@ private:
     BaseMesh* _manipulateBaseMesh = nullptr;
     BaseMesh* _closestBaseMesh = nullptr;
     bool      _isSnapping = false;
+
+    // Camera Focused
+    bool    _isFocusedCamera                = false;
+    Vector3 _focusedCameraTargetPosition    = Vector3::Zero;
+    Vector3 _focusedCameraStartPosition     = Vector3::Zero;
+    float   _focusedLerpScale               = 0.1f;
+
 public:
     class ManipulateCommand : public UmCommand
     {

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/CommandCore/CommandManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/CommandCore/CommandManager.cpp
@@ -15,9 +15,9 @@ void ECommandManager::Undo()
     ClampCommandStack();
 }
 
-void ECommandManager::Undo(UINT cnt)
+void ECommandManager::Undo(size_t cnt)
 {
-    for (UINT i = 0; i < cnt; ++i)
+    for (size_t i = 0; i < cnt; ++i)
     {
         if (true == _undoStack.empty())
         {
@@ -59,9 +59,9 @@ void ECommandManager::Redo()
     ClampCommandStack();
 }
 
-void ECommandManager::Redo(UINT cnt)
+void ECommandManager::Redo(size_t cnt)
 {
-    for (UINT i = 0; i < cnt; ++i)
+    for (size_t i = 0; i < cnt; ++i)
     {
         if (true == _redoStack.empty())
         {

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/CommandCore/CommandManager.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/CommandCore/CommandManager.h
@@ -31,8 +31,8 @@ public:
 
     void SetMaxCommandSize(size_t size);
 
-    inline const std::shared_ptr<UmCommand>& GetCommandFromUndoStack(int index) const { return _undoStack[index]; }
-    inline const std::shared_ptr<UmCommand>& GetCommandFromRedoStack(int index) const { return _redoStack[index]; }
+    inline const std::shared_ptr<UmCommand>& GetCommandFromUndoStack(size_t index) const { return _undoStack[index]; }
+    inline const std::shared_ptr<UmCommand>& GetCommandFromRedoStack(size_t index) const { return _redoStack[index]; }
 
     inline size_t GetUndoStackSize() const { return _undoStack.size(); }
     inline size_t GetRedoStackSize() const { return _redoStack.size(); }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/CommandCore/CommandManager.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/CommandCore/CommandManager.h
@@ -34,8 +34,8 @@ public:
     inline const std::shared_ptr<UmCommand>& GetCommandFromUndoStack(int index) const { return _undoStack[index]; }
     inline const std::shared_ptr<UmCommand>& GetCommandFromRedoStack(int index) const { return _redoStack[index]; }
 
-    inline int GetUndoStackSize() const { return static_cast<int>(_undoStack.size()); }
-    inline int GetRedoStackSize() const { return static_cast<int>(_redoStack.size()); }
+    inline size_t GetUndoStackSize() const { return _undoStack.size(); }
+    inline size_t GetRedoStackSize() const { return _redoStack.size(); }
 
     inline const auto UndoStackBegin() const { return _undoStack.begin(); }
     inline const auto UndoStackEnd() const { return _undoStack.end(); }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/CommandCore/CommandManager.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/CommandCore/CommandManager.h
@@ -20,11 +20,11 @@ public:
     }
 
     void Undo();
-    void Undo(UINT cnt);
+    void Undo(size_t cnt);
     bool Undo(CommandQueue::const_iterator itr);
 
     void Redo();
-    void Redo(UINT cnt);
+    void Redo(size_t cnt);
     bool Redo(CommandQueue::const_iterator itr);
 
     void Clear();


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-29/editor_system

---

## 🛠️ 변경 사항
- Dynamic Camera
	a. 이동 관련 Min-Max Speed 변수 추가.
	b. 카메라가 동작 중인지 여부 반환 함수 추가
	c. PivotPosition도 설정 가능하게 변경
	d. Update함수 도중 필요 없는 변수 제거
	e. MoveScale 변수 제거. MoveSpeed랑 혼용
- SceneTool
	a. SetCameraFocusObject -> SetCameraToObject로 변경. (유연하게 쓰기 위해 인자를 받는 방식으로 변경)
	b. CameraFocus 중 선형 보간을 하도록 변경
 	c. Manipulate에 마우스 델타가 존재하는 경우에만 커맨드를 실행하도록 변경
	d. Manipulate가 호출중일 때만 관련 단축키가 동작하도록 변경
	e. RayPicker 평가 값이 false일 시 Focus 리셋하는 기능 추가
- HierarchyTool
	a. 더블 클릭 시 SceneView가 해당 객체를 SetCameraToObject하는 기능 추가
	b. Transform의 Drag&Drop을 Frame에다 끌어놓을 경우 Root(부모가 없음)상태로 변경하는 기능 추가
- InspectorTool
	a. FocusObject를 초기화하는 함수 추가 (outline 및 Manipulate 포함)
- FocusCommand
	a. 이미 포커싱 중인 객체라면 넘기도록 변경
- CommandTool
	a. 커맨드가 갱신될 때 스크롤을 내리도록 변경
	b. 사이즈 관련 함수 및 변수 size_t 자료형으로 변경
- DetachChildrenCommand
	a. 잘못된 Excute 성공 여부 반환 처리에 대한 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
- Git Issue: #339
