### PR TITLE
[FIX/VG-340] OnResize 함수 작동오류 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GraphicsEngine/Device.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Device.cpp
@@ -394,7 +394,7 @@ void Device::ResizeSwapChain()
     if (!_onResize)
         return;
 
-    GRAPHICS_ASSERT(_device || _swapChain, L"");    
+    GRAPHICS_ASSERT(_device || _swapChain, L"");
 
     _commandList->Reset(_commandAllocator.Get(), nullptr);
 
@@ -416,7 +416,7 @@ void Device::ResizeSwapChain()
 
     DXGI_MODE_DESC prevMode = _mode;
     _mode                   = _newMode;
-    Global::dxResourceManager->ResizeResource(prevMode);
+    //Global::dxResourceManager->ResizeResource(prevMode);
 
     _onResize  = false;
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/RenderTarget.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/RenderTarget.cpp
@@ -59,6 +59,9 @@ void RenderTarget::ResizeResource(Resolution resolution)
 {
     _currentState = D3D12_RESOURCE_STATE_RENDER_TARGET;
 
+    _desc.Width = resolution.Width;
+    _desc.Height = resolution.Height;
+
     _viewPort    = {.Width = (FLOAT)resolution.Width, .Height = (FLOAT)resolution.Height, .MinDepth = 0.f, .MaxDepth = 1.f};
     _scissorRect = {.right = (LONG)resolution.Width, .bottom = (LONG)resolution.Height};
     _resolution  = resolution;


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-340/graphics_on_resize_function_error

---

## 🛠️ 변경 사항
- `ResizeSwapChain` 함수에서 리소스 크기 조정 호출을 주석 처리하여 백버퍼 해상도 변경에 따른 리소스 해상도 변경을 임시로 제한
- RenderTarget Class에서 ReszieResource 함수 호출 시 리소스의 크기를 재설정하는 부분 누락된거 추가

---

## ✅ 체크리스트
- [ ] 코드에 불필요한 로그는 제거했나요?
- [ ] 코드에 불필요한 주석은 제거했나요?
- [ ] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [ ] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #361 
- Jira Ticket Number: VG-340
