### PR TITLE
[REFACTOR/VG-28] 로드된 씬 오브젝트 추가가 파괴 이후 지연실행 되도록 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
@@ -630,6 +630,10 @@ void ESceneManager::LoadScene(std::string_view sceneName, LoadSceneMode mode)
         if (false == _lodedSceneList.empty())
         {
             _prevScene = _setting.MainScene;
+            for (auto& scene : _lodedSceneList)
+            {
+                scene->_isLoaded = false;
+            }
         }
         _setting.MainScene = scene->Path;
         _addComponentsQueue.clear();

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
@@ -148,6 +148,7 @@ void ESceneManager::SceneUpdate()
     ObjectsOnDisable();
     ObjectsDestroy();
     ObjectsMatrixUpdate();
+    ObjectsAddLoadScene();
 }
 
 void ESceneManager::Engine::AddGameObjectToLifeCycle(std::shared_ptr<GameObject> gameObject)
@@ -602,70 +603,58 @@ void ESceneManager::CreateEmptySceneAndLoad(std::string_view name, std::string_v
 
 void ESceneManager::LoadScene(std::string_view sceneName, LoadSceneMode mode)
 {
-    try
+    if (false == UmComponentFactory.HasScript())
     {
-        if (false == UmComponentFactory.HasScript())
+        UmComponentFactory.InitalizeComponentFactory();
+    }
+
+    Scene* scene = GetSceneByName(sceneName);
+    if (scene == nullptr)
+    {
+        return;
+    }
+
+    if (mode == LoadSceneMode::SINGLE)
+    {
+        for (auto& obj : _runtimeObjects)
         {
-            UmComponentFactory.InitalizeComponentFactory();
+            if (obj)
+            {
+                if (obj->_ownerScene == DONT_DESTROY_ON_LOAD_SCENE_NAME)
+                    continue;
+
+                GameObject::Destroy(obj.get());
+            }
         }
 
-        Scene* scene = GetSceneByName(sceneName);
-        if (scene == nullptr)
+        if (false == _lodedSceneList.empty())
         {
+            _prevScene = _setting.MainScene;
+        }
+        _setting.MainScene = scene->Path;
+        _addComponentsQueue.clear();
+        _addGameObjectsQueue.clear();
+        _waitAwakeVec.clear();
+        _waitStartVec.clear();
+        _lodedSceneList.clear();
+        UmCommandManager.Clear();
+        SetRendererSkyBox(scene);
+    }
+    else
+    {
+        Scene* mainScene = GetMainScene();
+        if (mainScene == nullptr)
+        {
+            engineCore->Logger.Log(LogLevel::LEVEL_WARNING, u8"메인 씬을 먼저 로드해주세요."_c_str);
             return;
         }
-
-        if (mode == LoadSceneMode::SINGLE)
+        if (scene->_isLoaded)
         {
-            for (auto& obj : _runtimeObjects)
-            {
-                if (obj)
-                {
-                    if (obj->_ownerScene == DONT_DESTROY_ON_LOAD_SCENE_NAME)
-                        continue;
-
-                    GameObject::Destroy(obj.get());
-                }
-            }
-
-            if (false == _lodedSceneList.empty())
-            {
-                _prevScene = _setting.MainScene;
-            }
-            _setting.MainScene = scene->Path;
-            _addComponentsQueue.clear();
-            _addGameObjectsQueue.clear();
-            _waitAwakeVec.clear();
-            _waitStartVec.clear();
-            _lodedSceneList.clear();
-            UmCommandManager.Clear();
-            SetRendererSkyBox(scene);
+            engineCore->Logger.Log(LogLevel::LEVEL_WARNING, u8"이미 로드된 씬은 추가 로드가 불가능합니다."_c_str);
+            return;
         }
-        else
-        {
-            Scene* mainScene = GetMainScene();
-            if (mainScene == nullptr)
-            {
-                engineCore->Logger.Log(LogLevel::LEVEL_WARNING, u8"메인 씬을 먼저 로드해주세요."_c_str);
-                return;
-            }
-            if (scene->_isLoaded)
-            {
-                engineCore->Logger.Log(LogLevel::LEVEL_WARNING, u8"이미 로드된 씬은 추가 로드가 불가능합니다."_c_str);
-                return;
-            }
-        }
-
-        DeserializeToGuid(scene->_guid);
-        scene->_isLoaded = true;
-        scene->_isDirty  = false;
-        _lodedSceneList.push_back(scene);
     }
-    catch (const std::exception& ex)
-    {
-        std::string msg = std::format("{}{}{}", sceneName, (const char*)u8" 로드 실패. ", ex.what());
-        UmLogger.Log(LogLevel::LEVEL_WARNING, msg);
-    }
+    _nextSceneGuid = scene->_guid;
 }
 
 void ESceneManager::UnloadScene(std::string_view sceneName) 
@@ -876,6 +865,32 @@ void ESceneManager::ObjectsMatrixUpdate()
                 root->UpdateMatrix();
             }
         }
+    }
+}
+
+void ESceneManager::ObjectsAddLoadScene() 
+{
+    if (false == _nextSceneGuid.empty())
+    {
+        auto sceneIter = _scenesMap.find(_nextSceneGuid);
+        if (sceneIter != _scenesMap.end())
+        {
+            Scene* scene = &sceneIter->second;
+            try
+            {
+                DeserializeToGuid(_nextSceneGuid);
+                scene->_isLoaded = true;
+                scene->_isDirty  = false;
+                _lodedSceneList.push_back(scene);
+            }
+            catch (const std::exception& ex)
+            {
+                std::string sceneName = scene->Name;
+                std::string msg       = std::format("{}{}{}", sceneName, (const char*)u8" 로드 실패. ", ex.what());
+                UmLogger.Log(LogLevel::LEVEL_WARNING, msg);
+            }
+        }
+        _nextSceneGuid.clear();
     }
 }
 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.h
@@ -63,7 +63,7 @@ public:
     { 
         return _guid.ToPath().stem().string();
     }
-    // get : 이 씬의 이름을 반환합니다.
+    // std::string : 이 씬의 이름을 반환합니다.
     PROPERTY(Name)
 
     GETTER_ONLY(std::string, Path)
@@ -581,10 +581,11 @@ private:
     void ObjectsFixedUpdate();       //FixedUpdate를 호출합니다.
     void ObjectsUpdate();            //Update 를 호출합니다.
     void ObjectsLateUpdate();        //LateUpdate를 호출합니다.
-    void ObjectsMatrixUpdate();      //오브젝트들의 행렬을 업데이트합니다.
     void ObjectsApplicationQuit();   //OnApplicationQuit를 호출합니다.
     void ObjectsOnDisable();         //OnDisable 예정인 컴포넌트들의 OnDisable 함수를 호출해줍니다.
     void ObjectsDestroy();           //Destroy 예정인 컴포넌트들의 OnDestroy 함수를 호출 한 뒤 파괴합니다.
+    void ObjectsMatrixUpdate();      //오브젝트들의 행렬을 업데이트합니다.
+    void ObjectsAddLoadScene();      //다음에 로드할 씬의 오브젝트들을 추가합니다.
 
 private:
     /*게임오브젝트의 Life cycle 수행 여부를 확인하는 함수*/
@@ -684,6 +685,9 @@ private:
 
     //로드된 씬 항목
     std::vector<Scene*> _lodedSceneList;
+
+    //다음에 로드할 씬
+    File::Guid _nextSceneGuid;
 
 protected:
     /// <summary>


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-28/delay_scene_load
---

## 🛠️ 변경 사항
- 로드된 씬 오브젝트 추가가 파괴 이후 지연 추가 되도록 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---
