### PR TITLE
[FIX/VG-29] AssetBrowser 우 클릭 안먹는 버그 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
@@ -940,12 +940,13 @@ void EditorAssetBrowserTool::UpdateFolderEntriesInput()
             }
             ImGui::EndMenu();
         }
-        if (-1 == _copyBuffer.first) ImGui::BeginDisabled();
+        int copyState= _copyBuffer.first;
+        if (-1 == copyState) ImGui::BeginDisabled();
         if (ImGui::MenuItem("Paste"))
         {
             PasteFile();
         }
-        if (-1 == _copyBuffer.first) ImGui::EndDisabled();
+        if (-1 == copyState) ImGui::EndDisabled();
 
         if (ImGui::MenuItem("Copy Path"))
         {

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
@@ -829,6 +829,7 @@ void EditorAssetBrowserTool::ShowFolderEntryPopup(AssetData& asset)
         {
             File::OpenFile(asset.Entry.path());
         }
+        if (asset.IsDirectory) ImGui::BeginDisabled();
         if (ImGui::MenuItem("Copy"))
         {
             SetCopyFileFromPath(asset.Entry.path());
@@ -837,6 +838,7 @@ void EditorAssetBrowserTool::ShowFolderEntryPopup(AssetData& asset)
         {
             SetCutFileFromPath(asset.Entry.path());
         }
+        if (asset.IsDirectory) ImGui::EndDisabled();
         if (ImGui::MenuItem("Rename"))
         {
             _rename.StartRename(asset.Entry.path());

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
@@ -1265,11 +1265,11 @@ void EditorAssetBrowserTool::ProcessInput()
             _zoomScale   = ImClamp(_zoomScale, 0.5f, 2.0f);
             _needRefresh = true;
         }
-        if (isKeyC)
+        if (isKeyC && fs::exists(_focusEntryPath))
         {
             SetCopyFileFromPath(_focusEntryPath);
         }
-        if (isKeyX)
+        if (isKeyX && fs::exists(_focusEntryPath))
         {
             SetCutFileFromPath(_focusEntryPath);
         }

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.cpp
@@ -110,7 +110,7 @@ void EditorAssetBrowserTool::OnFrameFocusStay()
 {
     if (fs::exists(_focusFolderPath) && fs::is_directory(_focusFolderPath))
     {
-        UpdateFolderEntryInput();
+        ProcessInput();
     }
 }
 
@@ -391,9 +391,9 @@ void EditorAssetBrowserTool::ShowFolderEntries()
             UmGameObjectFactory.WriteGameObjectFile(data.pTransform, relativePath.string());
             RefreshFocusFolderEntries();
         }
-
         ShowSearchBar();
         BeginFolderEntryFrame();
+        UpdateFolderEntriesInput();
         int showType = ReflectFields->ShowType;
         int pushStyleVar = 0;
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(15.0f, 4.0f)); ++pushStyleVar;// 아이콘 간격 조정
@@ -827,15 +827,15 @@ void EditorAssetBrowserTool::ShowFolderEntryPopup(AssetData& asset)
     {
         if (ImGui::MenuItem("Open"))
         {
-            UmFileSystem.RequestOpenFile(asset.Entry.path());
+            File::OpenFile(asset.Entry.path());
         }
         if (ImGui::MenuItem("Copy"))
         {
-            SetCopyFile();
+            SetCopyFileFromPath(asset.Entry.path());
         }
         if (ImGui::MenuItem("Cut"))
         {
-            SetCutFile();
+            SetCutFileFromPath(asset.Entry.path());
         }
         if (ImGui::MenuItem("Rename"))
         {
@@ -909,100 +909,8 @@ void EditorAssetBrowserTool::ProcessFolderEntryDragDrop(AssetData& asset)
     }
 }
 
-void EditorAssetBrowserTool::UpdateFolderEntryInput() 
+void EditorAssetBrowserTool::UpdateFolderEntriesInput()
 {
-    bool isRootpath         = (_focusFolderPath == UmFileSystem.GetRootPath());
-    bool isFileCopying      = (_copyBuffer.first == 0);
-    bool isFileCutting      = (_copyBuffer.first == 1);
-
-    bool isMouseXbutton1    = ImGui::IsMouseClicked(ImGuiMouseButton_XButton1, false);
-    bool isMouseXbutton2    = ImGui::IsMouseClicked(ImGuiMouseButton_XButton2, false);
-    bool isKeyEnter         = ImGui::IsKeyPressed(ImGuiKey_Enter, false);
-    bool isKeyDelete        = ImGui::IsKeyPressed(ImGuiKey_Delete, false); 
-    bool isKeyBackSpace     = ImGui::IsKeyPressed(ImGuiKey_Backspace, false);
-    bool isKeyEsc           = ImGui::IsKeyPressed(ImGuiKey_Escape, false);
-    bool isKeyCtrl          = ImGui::IsKeyDown(ImGuiKey_LeftCtrl);
-    bool isKeyF2            = ImGui::IsKeyPressed(ImGuiKey_F2, false);
-    bool isKeyC             = ImGui::IsKeyPressed(ImGuiKey_C, false);
-    bool isKeyX             = ImGui::IsKeyPressed(ImGuiKey_X, false);
-    bool isKeyV             = ImGui::IsKeyPressed(ImGuiKey_V, false);
-
-    AssetData* focusAssetData = GetAssetData(_focusEntryPath);
-    File::Path parentPath = _focusFolderPath.parent_path();
-
-    if (focusAssetData)
-    {
-        if (isKeyF2)
-        {
-            if (false == _rename.IsActive() || parentPath != _focusEntryPath)
-            {
-                _rename.StartRename(focusAssetData->Entry.path());
-            }
-        }
-        else if (isKeyEsc)
-        {
-            if (isFileCutting)
-            {
-                _copyBuffer.first = -1; // 클립보드 초기화
-            }
-            else if (_rename.IsActive())
-            {
-                _rename.CancelRename();
-            }
-        }
-        else if (isKeyDelete)
-        {
-            File::Path focusPath = _focusEntryPath;
-            Global::editorModule->OpenPopupBox("Delete File", [this, focusPath]() {
-                _rename.CancelRename();
-                if (ShowDeletePopupBox(focusPath))
-                {
-                    DeleteFileFromPath(focusPath);
-                }
-            });
-        }
-        else if (isKeyEnter && false == _rename.IsActive())
-        {
-            if (focusAssetData->IsDirectory)
-            {
-                SetFocusFolderPath(focusAssetData->Entry.path());
-            }
-            else
-            {
-                UmFileSystem.RequestOpenFile(focusAssetData->Entry.path());
-            }
-        }
-    }
-    if (isMouseXbutton1)
-    {
-        UndoPath();
-    }
-    else if (isMouseXbutton2)
-    {
-        RedoPath();
-    }
-    if (isKeyCtrl)
-    {
-        float wheelY = ImGui::GetIO().MouseWheel;
-        if (wheelY != 0.0f)
-        {
-            _zoomScale += wheelY * 0.1f;
-            _zoomScale   = ImClamp(_zoomScale, 0.5f, 2.0f);
-            _needRefresh = true;
-        }
-        if (isKeyC)
-        {
-            SetCopyFile();
-        }
-        if (isKeyX)
-        {
-            SetCutFile();
-        }
-        if (isKeyV)
-        {
-            PasteFile();
-        }
-    }
     if (ImGui::IsWindowHovered() && false == ImGui::IsAnyItemHovered())
     {
         if (ImGui::IsMouseClicked(ImGuiMouseButton_Right))
@@ -1030,10 +938,13 @@ void EditorAssetBrowserTool::UpdateFolderEntryInput()
             }
             ImGui::EndMenu();
         }
+        if (-1 == _copyBuffer.first) ImGui::BeginDisabled();
         if (ImGui::MenuItem("Paste"))
         {
             PasteFile();
         }
+        if (-1 == _copyBuffer.first) ImGui::EndDisabled();
+
         if (ImGui::MenuItem("Copy Path"))
         {
             File::CopyPathToClipBoard(_focusFolderPath);
@@ -1270,7 +1181,103 @@ EditorAssetBrowserTool::AssetData* EditorAssetBrowserTool::GetAssetData(const Fi
     return nullptr;
 }
 
-void EditorAssetBrowserTool::RefreshState() 
+void EditorAssetBrowserTool::ProcessInput()
+{
+    bool isRootpath    = (_focusFolderPath == UmFileSystem.GetRootPath());
+    bool isFileCopying = (_copyBuffer.first == 0);
+    bool isFileCutting = (_copyBuffer.first == 1);
+
+    bool isMouseXbutton1 = ImGui::IsMouseClicked(ImGuiMouseButton_XButton1, false);
+    bool isMouseXbutton2 = ImGui::IsMouseClicked(ImGuiMouseButton_XButton2, false);
+    bool isKeyEnter      = ImGui::IsKeyPressed(ImGuiKey_Enter, false);
+    bool isKeyDelete     = ImGui::IsKeyPressed(ImGuiKey_Delete, false);
+    bool isKeyBackSpace  = ImGui::IsKeyPressed(ImGuiKey_Backspace, false);
+    bool isKeyEsc        = ImGui::IsKeyPressed(ImGuiKey_Escape, false);
+    bool isKeyCtrl       = ImGui::IsKeyDown(ImGuiKey_LeftCtrl);
+    bool isKeyF2         = ImGui::IsKeyPressed(ImGuiKey_F2, false);
+    bool isKeyC          = ImGui::IsKeyPressed(ImGuiKey_C, false);
+    bool isKeyX          = ImGui::IsKeyPressed(ImGuiKey_X, false);
+    bool isKeyV          = ImGui::IsKeyPressed(ImGuiKey_V, false);
+
+    AssetData* focusAssetData = GetAssetData(_focusEntryPath);
+    File::Path parentPath     = _focusFolderPath.parent_path();
+
+    if (focusAssetData)
+    {
+        if (isKeyF2)
+        {
+            if (false == _rename.IsActive() || parentPath != _focusEntryPath)
+            {
+                _rename.StartRename(focusAssetData->Entry.path());
+            }
+        }
+        else if (isKeyEsc)
+        {
+            if (isFileCutting)
+            {
+                _copyBuffer.first = -1; // 클립보드 초기화
+            }
+            else if (_rename.IsActive())
+            {
+                _rename.CancelRename();
+            }
+        }
+        else if (isKeyDelete)
+        {
+            File::Path focusPath = _focusEntryPath;
+            Global::editorModule->OpenPopupBox("Delete File", [this, focusPath]() {
+                _rename.CancelRename();
+                if (ShowDeletePopupBox(focusPath))
+                {
+                    DeleteFileFromPath(focusPath);
+                }
+            });
+        }
+        else if (isKeyEnter && false == _rename.IsActive())
+        {
+            if (focusAssetData->IsDirectory)
+            {
+                SetFocusFolderPath(focusAssetData->Entry.path());
+            }
+            else
+            {
+                UmFileSystem.RequestOpenFile(focusAssetData->Entry.path());
+            }
+        }
+    }
+    if (isMouseXbutton1)
+    {
+        UndoPath();
+    }
+    else if (isMouseXbutton2)
+    {
+        RedoPath();
+    }
+    if (isKeyCtrl)
+    {
+        float wheelY = ImGui::GetIO().MouseWheel;
+        if (wheelY != 0.0f)
+        {
+            _zoomScale += wheelY * 0.1f;
+            _zoomScale   = ImClamp(_zoomScale, 0.5f, 2.0f);
+            _needRefresh = true;
+        }
+        if (isKeyC)
+        {
+            SetCopyFileFromPath(_focusEntryPath);
+        }
+        if (isKeyX)
+        {
+            SetCutFileFromPath(_focusEntryPath);
+        }
+        if (isKeyV)
+        {
+            PasteFile();
+        }
+    }
+}
+
+void EditorAssetBrowserTool::RefreshState()
 {
     if (false == fs::exists(_focusFolderPath))
     {
@@ -1420,17 +1427,17 @@ void EditorAssetBrowserTool::RedoPath()
     }
 }
 
-void EditorAssetBrowserTool::SetCopyFile()
+void EditorAssetBrowserTool::SetCopyFileFromPath(const File::Path& path)
 {
     _copyBuffer.first  = 0;
-    _copyBuffer.second = _focusEntryPath;
+    _copyBuffer.second = path;
     UmFileSystem.RequestCopyFile(_copyBuffer.second);
 }
 
-void EditorAssetBrowserTool::SetCutFile()
+void EditorAssetBrowserTool::SetCutFileFromPath(const File::Path& path)
 {
     _copyBuffer.first  = 1;
-    _copyBuffer.second = _focusEntryPath;
+    _copyBuffer.second = path;
 }
 
 void EditorAssetBrowserTool::PasteFile() 

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.h
@@ -142,7 +142,7 @@ private:
     
     std::bitset<FLAG_SIZE> _flags;                      // 플래그 비트셋 (예: 메타 파일 표시 여부 등)
 
-    std::pair<int, File::Path> _copyBuffer = {-1, ""};   // 복사 버퍼 (first가 0이면 복사, 1이면 잘라넣기)
+    std::pair<int, File::Path> _copyBuffer = {-1, ""};   // 복사 버퍼 (first가 -1이면 비어있음/동작 없음, 0이면 복사, 1이면 잘라넣기)
     std::vector<std::function<void()>> _delayEvent;     // 후처리 이벤트 (보통 삭제나 추가 등의 작업을 함)
 
     /* 에셋 정보 저장 테이블 및 리스트 */

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/AssetBrowser/EditorAssetBrowserTool.h
@@ -82,14 +82,15 @@ private:
     void OnFrameFocusExit() override;
 
 public:
+    void ProcessInput();
     void RefreshState();
     void RefreshFocusFolderEntries();
     void SetFocusFolderPath(const File::Path& path, bool pushStack = true);
     void SetFocusEntryPath(const File::Path& path);
     void UndoPath();
     void RedoPath();
-    void SetCopyFile();
-    void SetCutFile();
+    void SetCopyFileFromPath(const File::Path& path);
+    void SetCutFileFromPath(const File::Path& path);
     void PasteFile();
     bool DeleteFileFromPath(const File::Path& path);
          
@@ -112,12 +113,12 @@ private:
 
     /* 콘텐츠 뷰 콜럼 */
     void ShowFolderEntries();
+    void UpdateFolderEntriesInput();
     void ShowSearchBar();   
     void ShowFolderEntryToList(AssetData& asset);  
     void ShowFolderEntryToIcon(AssetData& asset);  
     void ShowFolderEntryPopup(AssetData& asset);
     void ProcessFolderEntryDragDrop(AssetData& asset);
-    void UpdateFolderEntryInput();
     void BeginFolderEntryFrame();
 
     /* 팝업 박스 메서드 */
@@ -141,7 +142,7 @@ private:
     
     std::bitset<FLAG_SIZE> _flags;                      // 플래그 비트셋 (예: 메타 파일 표시 여부 등)
 
-    std::pair<int, File::Path> _copyBuffer = {0, ""};   // 복사 버퍼 (first가 0이면 복사, 1이면 잘라넣기)
+    std::pair<int, File::Path> _copyBuffer = {-1, ""};   // 복사 버퍼 (first가 0이면 복사, 1이면 잘라넣기)
     std::vector<std::function<void()>> _delayEvent;     // 후처리 이벤트 (보통 삭제나 추가 등의 작업을 함)
 
     /* 에셋 정보 저장 테이블 및 리스트 */

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/System/FileSystem.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/FileSystem/System/FileSystem.cpp
@@ -435,7 +435,7 @@ void EFileSystem::CheckFileContextIntegrity(const File::Path& path)
 {
     if (fs::exists(path))
     {
-        if (false == HasContext(path))
+        if (IsValidExtension(path.extension()) && false == HasContext(path))
         {
             RegisterContext(path);
         }


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-29/assetbrowser_bug

---

## 🛠️ 변경 사항
- AssetBrowser 우 클릭 안먹는 버그 수정
- 폴더 Copy못하는 부분 가시성 향상

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?
