### PR TITLE
[FIX/VG-28] 컴포넌트 DrawPropertysEvent에서 AddComponent 하면 터지는 버그 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GameCore/GameObject/GameObject.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GameCore/GameObject/GameObject.cpp
@@ -203,17 +203,25 @@ void GameObject::OnInspectorStay()
 
         if (false == _components.empty())
         {
-            size_t componentsCount = _components.size();
             const std::vector<std::shared_ptr<GameObject>>* originPrefab = nullptr;
             if (pPrefabObject != nullptr)
             {
                 originPrefab = UmGameObjectFactory.GetOriginPrefab(pPrefabObject->_prefabGuid);
             }
 
+            //안전한 순회 및 동적 할당 반복 방지를 위한 thread_local 순회용 컨테이너
+            static thread_local std::vector<Component*> components;
+            components.clear();
+            for (auto& component : _components)
+            {
+                components.push_back(component.get());
+            }
+
+            size_t componentsCount = components.size();
             for (int i = 0; i < componentsCount; i++)
             {
-                std::shared_ptr<Component>& component = _components[i];
-                ImGui::PushID(component.get());
+                Component* component = components[i];
+                ImGui::PushID(component);
                 {
                     const char* className = component->ClassName();
                     auto componentContextPopup = [&]() 
@@ -223,7 +231,7 @@ void GameObject::OnInspectorStay()
                             if (ImGui::MenuItem("Copy Component"))
                             {
                                 YAML::Emitter componentYamlEmitter;
-                                componentYamlEmitter << UmComponentFactory.SerializeToYaml(component.get());
+                                componentYamlEmitter << UmComponentFactory.SerializeToYaml(component);
                                 std::wstring componentData = U8ToWString(componentYamlEmitter.c_str());
                                 File::SetClipboardText(componentData);
                             }
@@ -231,11 +239,11 @@ void GameObject::OnInspectorStay()
                             {
                                 if (false == editorModule->PlayMode.IsPlay())
                                 {
-                                    UmCommandManager.Do<Command::EditorScene::DestroyComponentCommand>(component.get());
+                                    UmCommandManager.Do<Command::EditorScene::DestroyComponentCommand>(component);
                                 }
                                 else
                                 {
-                                    GameObject::Destroy(component.get());
+                                    GameObject::Destroy(component);
                                 }
                             }
                             ImGui::EndPopup();
@@ -340,7 +348,7 @@ void GameObject::OnInspectorStay()
                                         if (ImGui::Button("Revert"))
                                         {
                                             UmGameObjectFactory.UnsetOverrideFlag(pData);
-                                            UmComponentFactory.RevertOverrideField(component.get(), rflName.data());
+                                            UmComponentFactory.RevertOverrideField(component, rflName.data());
                                             GetScene().IsDirty = true;
                                         }
                                     }

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Test/Component/TestComponent.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Test/Component/TestComponent.cpp
@@ -97,3 +97,11 @@ void TestComponent::DeserializedReflectEvent()
     UmLogger.Log(LogLevel::LEVEL_DEBUG, "DeserializedReflectEvent");
 
 }
+
+void TestComponent::ImGuiDrawPropertysEvent() 
+{
+    if (ImGui::Button(u8"테스트 컴포넌트 추가"_c_str))
+    {
+        AddComponent<TestComponent>();
+    }
+}

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Test/Component/TestComponent.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Test/Component/TestComponent.h
@@ -70,4 +70,6 @@ protected:
 
     virtual void SerializedReflectEvent() override;
     virtual void DeserializedReflectEvent() override;
+
+    void ImGuiDrawPropertysEvent() override;
 };


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-28/game_object_inspector

---

## 🛠️ 변경 사항
- [컴포넌트 DrawPropertysEvent에서 AddComponent 하면 터지는 버그 수정]
- 
---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #374 
- Jira Ticket Number: VG-374
