### PR TITLE
[FEATURE/VG-352] 비동기 리소스 로드 방식 개선

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
@@ -1852,6 +1852,7 @@ void ESceneManager::EraseSceneGUID(std::string_view sceneName, const File::Guid 
 template <typename T>
 void ESceneManager::SceneResourceManager::UpdateRenderResource(RenderResource<T>& resource)
 {
+    std::list<std::tuple<std::weak_ptr<Component>, File::Path, std::function<void()>>> tempResource;
     std::tuple<std::weak_ptr<Component>, File::Path, std::function<void()>> curr;
     while (false == resource.ResourceLoadQueue.empty())
     {
@@ -1869,10 +1870,22 @@ void ESceneManager::SceneResourceManager::UpdateRenderResource(RenderResource<T>
                         auto findIter = resource.RenderResource.find(path);
                         if (findIter == resource.RenderResource.end())
                         {
-                            auto newResource = UmResourceManager->LoadResource<T>(path.string());                       
+                            auto newResource = UmResourceManager->LoadResource<T>(path.string(), func);
                             resource.RenderResource[path] = newResource;
                         }
-                        func();
+                        else
+                        {
+                            std::shared_ptr<T> resource = UmResourceManager->LoadResource<T>(path.string(), func);
+                            if (resource->IsValid())
+                            {
+                                func();
+                            }
+                            else
+                            {
+                                tempResource.push_back(curr);
+                                continue;
+                            }
+                        }
                     }
                 }
                 else
@@ -1887,6 +1900,11 @@ void ESceneManager::SceneResourceManager::UpdateRenderResource(RenderResource<T>
                 }
             }
         }
+    }
+
+    for (auto& tuple : tempResource)
+    {
+        resource.ResourceLoadQueue.push(tuple);
     }
 }
 

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Mesh/SkeletalMeshRenderer.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Mesh/SkeletalMeshRenderer.cpp
@@ -93,22 +93,23 @@ void SkeletalMeshRenderer::LoadModel()
         if (path != File::NULL_PATH)
         {
             std::wstring modelPath = U8ToWString(path);
-            UmGraphics.LoadResource(modelPath, Renderer.get(), [this]()
-                { 
-                    auto& animation = Renderer->GetModel()->GetAnimation();
-                    auto& skeleton  = Renderer->GetModel()->GetSkeleton();
-                    if (animation != nullptr && skeleton != nullptr)
-                    {
-                        std::shared_ptr<Animator> animator(new Animator);
-                        animator->Initialize(animation, skeleton);
-                        animator->SetActive(&EnableInHierarchy);
-                        UmGraphics.RegisterComponent(animator.get());
-                        Renderer->SetAnimator(animator);
-                        Renderer->OnCustomDepth(PostProcess::BLOOM);
-                        this->InitMaterial();
-                    }
-                    OnChangedModel();
-                });
+            UmGraphics.LoadResource(modelPath, Renderer.get());            
+            Renderer->Initialize();
+
+            auto& animation = Renderer->GetModel()->GetAnimation();
+            auto& skeleton  = Renderer->GetModel()->GetSkeleton();
+            if (animation != nullptr && skeleton != nullptr)
+            {
+                std::shared_ptr<Animator> animator(new Animator);
+                animator->Initialize(animation, skeleton);
+                animator->SetActive(&EnableInHierarchy);
+                UmGraphics.RegisterComponent(animator.get());
+                Renderer->SetAnimator(animator);
+                Renderer->OnCustomDepth(PostProcess::BLOOM);
+                this->InitMaterial();
+            }
+
+            OnChangedModel();
         }
     }
 }

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Mesh/StaticMeshRenderer.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Mesh/StaticMeshRenderer.cpp
@@ -37,13 +37,12 @@ void StaticMeshRenderer::LoadModel()
         if (path != File::NULL_PATH)
         {
             std::wstring modelPath = U8ToWString(path);
-            UmGraphics.LoadResource(modelPath, Renderer.get(), [this]()
-            {
-                Renderer->OnCustomDepth(PostProcess::BLOOM);
-                transform->SetChangeFlag();
-                this->InitMaterial();
-            });
-            
+            UmGraphics.LoadResource(modelPath, Renderer.get());
+            Renderer->Initialize();
+
+            Renderer->OnCustomDepth(PostProcess::BLOOM);
+            transform->SetChangeFlag();
+            InitMaterial();            
         }
     }
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Animation.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Animation.cpp
@@ -59,6 +59,5 @@ void Animation::LoadAnimation(const aiScene* scene)
     }
 }
 
-void Animation::LoadResource(const std::filesystem::path& filePath)
-{
+void Animation::LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback) {
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Animation.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Animation.h
@@ -29,7 +29,7 @@ public:
 public:
     void LoadAnimation(const struct aiScene* scene);
     // Resource을(를) 통해 상속됨
-    void LoadResource(const std::filesystem::path& filePath) override;
+    void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) override;
 
 private:
     std::unordered_map<std::string, Channel> _animations;

--- a/Source/GA6thFinal_Framework/GraphicsEngine/ComputeShader.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/ComputeShader.cpp
@@ -1,7 +1,7 @@
 ﻿#include "pch.h"
 #include "ComputeShader.h"
 
-void ComputeShader::LoadResource(const std::filesystem::path& filePath)
+void ComputeShader::LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback)
 {
     CompileShader(filePath.c_str(), "cs_main", "cs_5_1");
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/ComputeShader.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/ComputeShader.h
@@ -9,5 +9,5 @@ public:
 
 public:
     // Shader을(를) 통해 상속됨
-    void LoadResource(const std::filesystem::path& filePath) override;
+    void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) override;
 };

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Externs.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Externs.h
@@ -2,21 +2,22 @@
 
 namespace Global
 {
-    extern Device*                   device;
-    extern Renderer*                 renderer;
-    extern CommandController*        commandController;
-    extern DXResourceManager*        dxResourceManager;
-    extern MultiRenderTargetManager* multiRenderTargetManager;
-    extern ResourceManager*          resourceManager;
-    extern ViewManager*              viewManager;
-    extern AnimationCore*            animationCore;
-    extern LightCore*                lightCore;
-    extern ParticleManager*          particleManager;
-    extern DebugDrawCore*            debugDrawCore;
-    extern RenderPassDatas*          renderPassDatas;
-    extern ModuleManager*            moduleManager;
-    extern PipelineStateManager*     pipelineStateManager;
-    extern ThreadPool*               threadPool;
-    extern bool                      isRayTracing;
-    extern SceneTransitionCore*      sceneTransitionCore;
+    extern Device*                     device;
+    extern Renderer*                   renderer;
+    extern CommandController*          commandController;
+    extern DXResourceManager*          dxResourceManager;
+    extern MultiRenderTargetManager*   multiRenderTargetManager;
+    extern ResourceManager*            resourceManager;
+    extern ViewManager*                viewManager;
+    extern AnimationCore*              animationCore;
+    extern LightCore*                  lightCore;
+    extern ParticleManager*            particleManager;
+    extern DebugDrawCore*              debugDrawCore;
+    extern RenderPassDatas*            renderPassDatas;
+    extern ModuleManager*              moduleManager;
+    extern PipelineStateManager*       pipelineStateManager;
+    extern ThreadPool*                 threadPool;
+    extern bool                        isRayTracing;
+    extern SceneTransitionCore*        sceneTransitionCore;
+    extern D3D12_GPU_DESCRIPTOR_HANDLE dummyTextureHandle;
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Font.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Font.cpp
@@ -9,7 +9,7 @@ Font::~Font()
 {
 }
 
-void Font::LoadResource(const std::filesystem::path& filePath)
+void Font::LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback)
 {
     ID3D12Device*       device = Global::device->GetDevice();
     ResourceUploadBatch resourceUpload(device);

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Font.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Font.h
@@ -12,7 +12,7 @@ public:
 
 public:
 	// Resource을(를) 통해 상속됨
-    void LoadResource(const std::filesystem::path& filePath) override;	
+    void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) override;	
 
 private:
     DescriptorHandles           _handle;

--- a/Source/GA6thFinal_Framework/GraphicsEngine/GeometryShader.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/GeometryShader.cpp
@@ -1,7 +1,7 @@
 ﻿#include "pch.h"
 #include "GeometryShader.h"
 
-void GeometryShader::LoadResource(const std::filesystem::path& filePath)
+void GeometryShader::LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback)
 {
     CompileShader(filePath.c_str(), "gs_main", "gs_5_1");
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/GeometryShader.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/GeometryShader.h
@@ -9,5 +9,5 @@ public:
 
 public:
     // Shader을(를) 통해 상속됨
-    void LoadResource(const std::filesystem::path& filePath) override;
+    void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) override;
 };

--- a/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsCore.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsCore.cpp
@@ -145,15 +145,9 @@ void GraphicsCore::RegisterComponent(const std::string_view renderSceneName, Lig
     _lightCore->RegisterLight(renderSceneName, component);
 }
 
-void GraphicsCore::LoadResource(std::wstring_view filePath, MeshRenderer* component, const std::function<void()>& callback)
+void GraphicsCore::LoadResource(std::wstring_view filePath, MeshRenderer* component) const
 {
     component->SetModel(_resourceManager->LoadResource<Model>(filePath));
-
-    _resourceLoadQueue.emplace([this, component, callback]()
-    {
-        component->Initialize();
-        callback();
-    });
 }
 
 void GraphicsCore::LoadResource(const std::wstring_view filePath, SpriteRenderer* component) const
@@ -249,15 +243,8 @@ void GraphicsCore::UpdateAnimation(const float deltaTime) const
 
 void GraphicsCore::Update(const float deltaTime)
 {
-    _threadPool->Update();
-
-    while (!_resourceLoadQueue.empty())
-    {
-        auto task = _resourceLoadQueue.front();
-        task();
-        _resourceLoadQueue.pop();
-    }
-
+    _threadPool->Update();    
+    _resourceManager->Update();
     _particleManager->Update(deltaTime);
     _lightCore->Update(deltaTime);
     _renderer->Update(deltaTime);

--- a/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsCore.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsCore.h
@@ -16,7 +16,7 @@ public:
     D3D12_CPU_DESCRIPTOR_HANDLE GetBackBufferHandle() const;
     ID3D12GraphicsCommandList*  GetCommandList() const;
     RenderPassProperties&       GetRenderPassProperties() const;
-    SceneTransitionCore*  GetSceneTransitionCore() const;
+    SceneTransitionCore*        GetSceneTransitionCore() const;
 
 public:
     void SetCamera(std::string_view renderSceneName, std::shared_ptr<Camera> camera) const;
@@ -34,7 +34,7 @@ public:
     void RegisterComponent(std::string_view renderSceneName, Light* component) const;
 
 public:
-    void LoadResource(std::wstring_view filePath, MeshRenderer* component, const std::function<void()>& callback);
+    void LoadResource(std::wstring_view filePath, MeshRenderer* component) const;
     void LoadResource(std::wstring_view filePath, SpriteRenderer* component) const;
     void LoadResource(std::wstring_view filePath, FontRenderer* component) const;
     void LoadTextureResource(std::wstring_view filePath, class ParticleEmitter* component) const;
@@ -79,7 +79,4 @@ private:
     class PipelineStateManager*       _pipelineStateManager;
     class ThreadPool*                 _threadPool;
     class SceneTransitionCore*        _sceneTransitionCore;
-
-private:
-    std::queue<std::function<void()>> _resourceLoadQueue;
 };

--- a/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsEngine.vcxproj
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsEngine.vcxproj
@@ -648,12 +648,6 @@ xcopy /Y /I "$(ProjectDir)ThirdParty\bin\*.*" "$(SolutionDir)GameEngine\ThirdPar
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseEditor|x64'">true</ExcludedFromBuild>
     </FxCompile>
-    <FxCompile Include="..\Shaders\cs_particle_reorder.hlsl">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DebugEditor|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseEditor|x64'">true</ExcludedFromBuild>
-    </FxCompile>
     <FxCompile Include="..\Shaders\cs_prefiltered_map.hlsl">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DebugEditor|x64'">true</ExcludedFromBuild>

--- a/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsEngine.vcxproj.filters
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsEngine.vcxproj.filters
@@ -125,7 +125,6 @@
     <FxCompile Include="..\Shaders\ps_volumetric_fog.hlsl">
       <Filter>Shaders\ps</Filter>
     </FxCompile>
-    <FxCompile Include="..\Shaders\cs_particle_reorder.hlsl" />
     <FxCompile Include="..\Shaders\ps_fade.hlsl" />
   </ItemGroup>
   <ItemGroup>
@@ -483,10 +482,11 @@
       <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="GraphicsController.cpp">
-    <Filter>소스 파일</Filter>
+      <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="SceneTransitionTechnique.cpp" />
     <ClCompile Include="FadePass.cpp" />
+    <ClCompile Include="SceneTransitionCore.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AccelerationStructureManager.h">
@@ -874,6 +874,7 @@
     </ClInclude>
     <ClInclude Include="SceneTransitionTechnique.h" />
     <ClInclude Include="FadePass.h" />
+    <ClInclude Include="SceneTransitionCore.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Shaders\CommonData.hlsli">

--- a/Source/GA6thFinal_Framework/GraphicsEngine/MeshShader.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/MeshShader.cpp
@@ -1,7 +1,7 @@
 ﻿#include "pch.h"
 #include "MeshShader.h"
 
-void MeshShader::LoadResource(const std::filesystem::path& filePath)
+void MeshShader::LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback)
 {
     CompileShader(filePath.c_str(), "ms_main", "ms_5_1");
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/MeshShader.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/MeshShader.h
@@ -9,5 +9,5 @@ public:
 
 public:
     // Shader을(를) 통해 상속됨
-    void LoadResource(const std::filesystem::path& filePath) override;
+    void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) override;
 };

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Model.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Model.cpp
@@ -47,14 +47,15 @@ void Model::BindMaterial(const UINT meshIndex, const Material& material)
     _material[meshIndex] = material;
 }
 
-void Model::LoadResource(const std::filesystem::path& filePath)
+void Model::LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback)
 {   
     //FBXConverter fbxConverter;
     //fbxConverter.ImportModel(filePath, this);
 
-    Global::threadPool->AddTask(ThreadPool::ThreadType::PARALLEL, [this, filePath](ID3D12GraphicsCommandList* commandList)
+    Global::threadPool->AddTask(ThreadPool::ThreadType::PARALLEL, [this, filePath, callback](ID3D12GraphicsCommandList* commandList)
     {
         FBXConverter fbxConverter;
         fbxConverter.ImportModel(commandList, filePath, this);
+        Global::resourceManager->EnqueueCallback(callback);
     });
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Model.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Model.h
@@ -13,6 +13,7 @@ public:
     virtual ~Model();
 
 public:
+    bool                                                      IsValid() const override { return !_meshes.empty(); }
     const std::shared_ptr<Animation>                          GetAnimation() const { return _animation; }
     const std::shared_ptr<Skeleton>                           GetSkeleton() const { return _skeleton; }
     const std::vector<std::unique_ptr<BaseMesh>>&             GetMeshes() const { return _meshes; }
@@ -32,7 +33,7 @@ public:
     void BindMaterial(const UINT meshIndex, const Material& material);
 
     // Resource을(를) 통해 상속됨
-    void LoadResource(const std::filesystem::path& filePath) override;
+    void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) override;
 
 private:
     std::vector<std::unique_ptr<BaseMesh>>             _meshes;

--- a/Source/GA6thFinal_Framework/GraphicsEngine/PixelShader.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/PixelShader.cpp
@@ -1,7 +1,7 @@
 ﻿#include "pch.h"
 #include "PixelShader.h"
 
-void PixelShader::LoadResource(const std::filesystem::path& filePath)
+void PixelShader::LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback)
 {
     CompileShader(filePath.c_str(), "ps_main", "ps_5_1");
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/PixelShader.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/PixelShader.h
@@ -9,5 +9,5 @@ public:
 
 public:
     // Shader을(를) 통해 상속됨
-    void LoadResource(const std::filesystem::path& filePath) override;
+    void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) override;
 };

--- a/Source/GA6thFinal_Framework/GraphicsEngine/RenderScene.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/RenderScene.cpp
@@ -360,7 +360,7 @@ void RenderScene::UpdateObject()
             else if (SKELETAL_MESH == type)
             {
                 _skeletalMeshInstanceIDs.push_back(instanceID);
-                _activeMeshes[type].emplace_back(materials[i], meshes[i].get(), customDepths[i], instanceID++, nullptr, skinnedBuffers[i].get());
+                _activeMeshes[type].emplace_back(materials[i], meshes[i].get(), customDepths[i], instanceID++, nullptr, Global::isRayTracing ? skinnedBuffers[i].get() : nullptr);
             }
         }
     }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Renderer.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Renderer.cpp
@@ -30,6 +30,11 @@
 #include "UITechnique.h"
 #include "SceneTransitionTechnique.h"
 
+namespace Global
+{
+    D3D12_GPU_DESCRIPTOR_HANDLE dummyTextureHandle;
+}
+
 Renderer::Renderer() : _totalTime{0.f} {}
 
 Renderer::~Renderer() {}
@@ -487,14 +492,14 @@ void Renderer::CreateDefaultTexture()
 
     ID3D12GraphicsCommandList* commandList = Global::device->GetCommandList();
     UpdateSubresources(commandList, texture.Get(), uploadHeap.Get(), 0, 0, 1, &textureData);
-    CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-        texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(texture.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
     commandList->ResourceBarrier(1, &barrier);
 
     std::shared_ptr<Texture> textureResource = std::make_shared<Texture>();
     textureResource->SetResource(texture.Get());
     textureResource->CreateShaderResourceView();
+    Global::dummyTextureHandle = textureResource->GetGPUHandle();
 
     Global::resourceManager->AddResource("BlackTexture", textureResource);
     _defaultResource.push_back(textureResource);

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Resource.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Resource.h
@@ -7,12 +7,15 @@ public:
     virtual ~Resource() = default;
 
 public:
+    virtual bool IsValid() const { return true; }
+
+public:
     const D3D12_CPU_DESCRIPTOR_HANDLE& GetCPUHandle() const { return _handle.CPU; }
     const D3D12_GPU_DESCRIPTOR_HANDLE& GetGPUHandle() const { return _handle.GPU; }
     const UINT& GetID() const { return _ID; }
 
 public:
-    virtual void LoadResource(const std::filesystem::path& filePath) = 0;
+    virtual void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) = 0;
 
 protected:
     ComPtr<ID3D12Resource> _resource;

--- a/Source/GA6thFinal_Framework/GraphicsEngine/ResourceManager.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/ResourceManager.cpp
@@ -4,3 +4,17 @@
 ResourceManager::ResourceManager() = default;
 
 ResourceManager::~ResourceManager() = default;
+
+void ResourceManager::Update()
+{
+    std::function<void()> callback = nullptr;
+
+    while (!_callbackQueue.empty())
+    {
+        if (_callbackQueue.try_pop(callback))
+        {
+            if (callback)
+                callback();
+        }
+    }
+}

--- a/Source/GA6thFinal_Framework/GraphicsEngine/ResourceManager.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/ResourceManager.h
@@ -9,7 +9,7 @@ public:
 
 public:
 	template<typename T> requires (std::is_base_of_v<Resource, T>)
-	std::shared_ptr<T> LoadResource(std::filesystem::path filePath)
+    std::shared_ptr<T> LoadResource(std::filesystem::path filePath, const std::function<void()>& callback = nullptr)
 	{      
         if (true == std::filesystem::exists(filePath))
         {
@@ -28,7 +28,7 @@ public:
 		if (resource.expired())
 		{
             sharedResource = std::make_shared<T>();
-            sharedResource->LoadResource(filePath);
+            sharedResource->LoadResource(filePath, callback);
 
             _resources[typeid(T)][filePath] = sharedResource;
 		}
@@ -42,7 +42,13 @@ public:
         _resources[typeid(T)][filePath] = resource;
     }
 
+    void EnqueueCallback(const std::function<void()>& callback) { _callbackQueue.push(callback); }
+
+public:
+    void Update();
+
 private:
     std::unordered_map<std::type_index, std::unordered_map<std::wstring, std::weak_ptr<Resource>>> _resources;
+    Concurrency::concurrent_queue<std::function<void()>> _callbackQueue;
     std::mutex _mutex;
 };

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Texture.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Texture.cpp
@@ -5,6 +5,11 @@
 #include <directxtk12/DDSTextureLoader.h>
 #include <DirectXTex.h>
 
+bool Texture::IsValid() const
+{
+    return _handle.GPU.ptr != Global::dummyTextureHandle.ptr;
+}
+
 void Texture::SetResource(ID3D12Resource* resource)
 {
     _resource = resource;
@@ -30,11 +35,11 @@ void Texture::CreateShaderResourceView()
     _size.cy = (LONG)desc.Height;
 }
 
-void Texture::LoadResource(const std::filesystem::path& filePath)
+void Texture::LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback)
 {
-    _handle.GPU = Global::resourceManager->LoadResource<Texture>(L"BlackTexture")->GetGPUHandle();
+    _handle.GPU = Global::dummyTextureHandle;
 
-    Global::threadPool->AddTask(ThreadPool::ThreadType::ASYNK, [this, filePath](ID3D12GraphicsCommandList*)
+    Global::threadPool->AddTask(ThreadPool::ThreadType::ASYNK, [this, filePath, callback](ID3D12GraphicsCommandList*)
         {
             HRESULT       hr     = S_OK;
             ID3D12Device* device = Global::device->GetDevice();
@@ -59,5 +64,7 @@ void Texture::LoadResource(const std::filesystem::path& filePath)
             resUpload.End(Global::commandController->GetCommandQueue(CommandQueueType::GRAPHICS_QUEUE));
 
             CreateShaderResourceView();
+            
+            Global::resourceManager->EnqueueCallback(callback);
         });
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Texture.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Texture.h
@@ -9,6 +9,7 @@ public:
 
 public:
     const SIZE& GetSize() const { return _size; }
+    bool        IsValid() const override;
 
 public:
     void SetResource(ID3D12Resource* resource);
@@ -16,7 +17,7 @@ public:
 
 public:
     // Resource을(를) 통해 상속됨
-    void LoadResource(const std::filesystem::path& filePath) override;
+    void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) override;
 
 private:
     SIZE _size;

--- a/Source/GA6thFinal_Framework/GraphicsEngine/ThreadPool.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/ThreadPool.cpp
@@ -26,6 +26,11 @@ ThreadPool::~ThreadPool()
     }
 }
 
+bool ThreadPool::IsParallelTaskDone() const
+{
+    return _taskQueue[PARALLEL].empty() && (0 == _parallelRemainingTasks);
+}
+
 void ThreadPool::AddTask(ThreadType type, const std::function<void(ID3D12GraphicsCommandList*)>& task)
 {
     if (ThreadType::PARALLEL == type)

--- a/Source/GA6thFinal_Framework/GraphicsEngine/ThreadPool.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/ThreadPool.h
@@ -12,6 +12,9 @@ public:
     ~ThreadPool();
 
 public:
+    bool IsParallelTaskDone() const;
+
+public:
     void AddTask(ThreadType type, const std::function<void(ID3D12GraphicsCommandList*)>& task);
 
 public:

--- a/Source/GA6thFinal_Framework/GraphicsEngine/VertexShader.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/VertexShader.cpp
@@ -1,7 +1,7 @@
 ﻿#include "pch.h"
 #include "VertexShader.h"
 
-void VertexShader::LoadResource(const std::filesystem::path& filePath)
+void VertexShader::LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback)
 {
     CompileShader(filePath.c_str(), "vs_main", "vs_5_1");
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/VertexShader.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/VertexShader.h
@@ -15,7 +15,7 @@ public:
 
 public:
     // Shader을(를) 통해 상속됨
-    void LoadResource(const std::filesystem::path& filePath) override;
+    void LoadResource(const std::filesystem::path& filePath, const std::function<void()>& callback = nullptr) override;
 
 private:    
     std::vector<std::string>              _savedSemanticNames;


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-352/thread_loading_improve

---

## 🛠️ 변경 사항
- ESceneManager::SceneResourceManager::UpdateRenderResource 함수에서 리소스 로드 큐 처리 방식을 변경하고, 리소스 유효성을 확인 후 콜백 함수를 호출하도록 변경했습니다.

- SkeletalMeshRenderer와 StaticMeshRenderer의 LoadModel 함수에서 콜백 없이 직접 초기화하는 방식으로 변경하여 코드 흐름을 간소화했습니다.

- GraphicsCore의 LoadResource 함수에서 콜백을 제거하고 직접 초기화하는 방식으로 변경했습니다.

- ResourceManager에 Update 함수를 추가하여 대기 중인 콜백을 처리할 수 있도록 했습니다.

- 여러 클래스에서 LoadResource 함수의 시그니처를 변경하여 비동기 처리를 유연하게 할 수 있도록 개선했습니다.

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?
