### PR TITLE
[FIX/VG-28] scene gizmo bug fix

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/GizmoManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/GizmoManager.cpp
@@ -59,7 +59,7 @@ void EGizmoManager::Draw()
             box.Extents = {2, 2, 2};
             SceneGizmo&   gizmo       = *pair.second;
             const Matrix& worldMatrix =  gizmo._ownerMatrix != nullptr ? *gizmo._ownerMatrix : gizmo._ownerComponenet.transform->GetWorldMatrix();
-            box.Transform(box, owner->transform->GetWorldMatrix());
+            box.Transform(box, worldMatrix);
             bool intersect = false == frustum.Intersects(box);
             return intersect;
         });

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/GizmoManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/GizmoManager.cpp
@@ -57,9 +57,11 @@ void EGizmoManager::Draw()
 
             BoundingBox box;
             box.Extents = {2, 2, 2};
+            SceneGizmo&   gizmo       = *pair.second;
+            const Matrix& worldMatrix =  gizmo._ownerMatrix != nullptr ? *gizmo._ownerMatrix : gizmo._ownerComponenet.transform->GetWorldMatrix();
             box.Transform(box, owner->transform->GetWorldMatrix());
-
-            return false == frustum.Intersects(box);
+            bool intersect = false == frustum.Intersects(box);
+            return intersect;
         });
 
         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/ItemDropSystem/Interface/IDropItem.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/ItemDropSystem/Interface/IDropItem.h
@@ -12,6 +12,7 @@ enum class ArtifactDropType
     ACCESSORY,        // 장신구
     REVELATION,       // 계시
     ERASE_REVELATION, // 계시 지우기
+    Consumable,       //소모품
 };
 
 /*아이템 정보 구조체*/


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-28/gizmo_bug_fix

---

## 🛠️ 변경 사항
- [기즈모 컬링시 잘못된 행렬 사용하는 버그 수정](https://github.com/Scarecrow37/VanishingGround/commit/6c278fbe9412a5695e8b611db757744c059a78c7)
- 
---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

