### PR TITLE
[FIX/VG-28] 씬 리소스 로드 안전하게 하도록 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/EngineCore/SceneManager.cpp
@@ -1984,17 +1984,31 @@ void ESceneManager::SceneResourceManager::UpdateRenderResource(RenderResource<T>
                 {
                     if (component->_gameObject->IsValid())
                     {
+                        auto SafeCallbackFunc = [weakPtr, path, func]() 
+                        {
+                            if (std::shared_ptr<Component> component = weakPtr.lock())
+                            {
+                                if (true == std::filesystem::exists(path))
+                                {
+                                    if (component->_gameObject->IsValid())
+                                    {
+                                        func();
+                                    }
+                                }
+                            }
+                        };
+
                         path = std::filesystem::absolute(path);
                         path = path.generic_string();
                         auto findIter = resource.RenderResource.find(path);
                         if (findIter == resource.RenderResource.end())
                         {
-                            auto newResource = UmResourceManager->LoadResource<T>(path.string(), func);
+                            auto newResource = UmResourceManager->LoadResource<T>(path.string(), SafeCallbackFunc);
                             resource.RenderResource[path] = newResource;
                         }
                         else
                         {
-                            std::shared_ptr<T> resource = UmResourceManager->LoadResource<T>(path.string(), func);
+                            std::shared_ptr<T> resource = UmResourceManager->LoadResource<T>(path.string(), SafeCallbackFunc);
                             if (resource->IsValid())
                             {
                                 func();


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-/scene_load_resource_safe

---

## 🛠️ 변경 사항
- 씬 리소스 로드 안전하게 하도록 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

