### PR TITLE
[FEATURE/VG-418] 렌더 패스 데이터 구조 및 UI, 그림자 맵 개선

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/RenderPassData/EditorRenderPassData.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/RenderPassData/EditorRenderPassData.cpp
@@ -2,131 +2,385 @@
 #include "EditorRenderPassData.h"
 #include "Engine/GraphicsCore/RenderPassDataHelper.h"
 
+void CenterText(const char* text)
+{
+    if (text == nullptr) return;
+    float columnWidth = ImGui::GetColumnWidth();
+    float textWidth = ImGui::CalcTextSize(text).x;
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (columnWidth - textWidth) * 0.5f);
+    ImGui::TextUnformatted(text);
+}
+
 EditorRenderPassData::EditorRenderPassData()
 {
     SetLabel("RenderPassData");
     SetDockLayout(ImGuiDir_Right);
 }
 
-EditorRenderPassData::~EditorRenderPassData()
-{
-}
+EditorRenderPassData::~EditorRenderPassData() = default;
 
 void EditShadowProperty(std::any& property)
 {
     auto& shadowProps = std::any_cast<ShadowPassProperty&>(property);
 
-    ImGui::DragFloat("Near Plane", &shadowProps.NearPlane, 0.01f, 0.01f, 100.0f);
-    ImGui::DragFloat("Far Plane", &shadowProps.FarPlane, 0.1f, 0.1f, 1000.0f);
-    ImGui::DragFloat("Split Factor", &shadowProps.SplitFactor, 0.01f, 0.01f, 1.0f);
-    ImGui::DragFloat("Offset1", &shadowProps.Offset1, 0.01f, 0.0f, 1000.0f);
-    ImGui::DragFloat("Offset2", &shadowProps.Offset2, 0.01f, 0.0f, 1000.0f);
+    if (ImGui::BeginTable("Shadow Properties", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+    {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Near Plane");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##NearPlane", &shadowProps.NearPlane, 0.01f, 0.01f, 100.0f, "%.2f");
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Far Plane");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##FarPlane", &shadowProps.FarPlane, 0.1f, 0.1f, 10000.0f, "%.1f");
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Split Factor");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::SliderFloat("##SplitFactor", &shadowProps.SplitFactor, 0.0f, 1.0f, "%.2f");
+        ImGui::PopItemWidth();
+
+        ImGui::EndTable();
+    }
 }
 
 void EditBloomProperty(std::any& property)
 {
     auto& bloomProps = std::any_cast<BloomPassProperty&>(property);
-    ImGui::DragFloat("Threshold", &bloomProps.Threshold, 0.01f, 0.0f, 100.0f);
-    ImGui::DragFloat("Intensity", &bloomProps.Intensity, 0.01f, 0.0f, 100.0f);
-    ImGui::DragFloat("Bloom Knee", &bloomProps.BloomKnee, 0.01f, 0.0f, 100.0f);
+
+    if (ImGui::BeginTable("Bloom Properties", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+    {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Threshold");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##Threshold", &bloomProps.Threshold, 0.01f, 0.0f, 100.0f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Intensity");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##Intensity", &bloomProps.Intensity, 0.01f, 0.0f, 100.0f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Bloom Knee");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##BloomKnee", &bloomProps.BloomKnee, 0.01f, 0.0f, 100.0f);
+        ImGui::PopItemWidth();
+
+        ImGui::EndTable();
+    }
 }
 
 void EditToneMappingProperty(std::any& property)
 {
     auto& toneMappingProps = std::any_cast<ToneMappingProperty&>(property);
-    ImGui::DragFloat("Exposure", &toneMappingProps.Exposure, 0.01f, -10.f, 10.0f);
-    ImGui::DragFloat("Saturation", &toneMappingProps.Saturation, 0.01f, 0.0f, 2.0f);
-    ImGui::DragFloat("Contrast", &toneMappingProps.Contrast, 0.01f, 0.0f, 2.0f);
-    ImGui::ColorEdit3("White Balance", &toneMappingProps.WhiteBalance.x, ImGuiColorEditFlags_Float);
+
+    if (ImGui::BeginTable("Tone Mapping Properties", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+    {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Exposure");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##Exposure", &toneMappingProps.Exposure, 0.01f, -10.f, 10.0f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Saturation");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##Saturation", &toneMappingProps.Saturation, 0.01f, 0.0f, 2.0f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Contrast");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##Contrast", &toneMappingProps.Contrast, 0.01f, 0.0f, 2.0f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("White Balance");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::ColorEdit3("##WhiteBalance", &toneMappingProps.WhiteBalance.x, ImGuiColorEditFlags_Float);
+        ImGui::PopItemWidth();
+
+        ImGui::EndTable();
+    }
 }
 
 void EditSSAOProperty(std::any& property)
 {
     auto& ssaoProps = std::any_cast<SSAOPassProperty&>(property);
-    ImGui::DragFloat("Radius", &ssaoProps.Radius, 0.01f, 0.f, 50.f);
-    ImGui::DragFloat("FallOff", &ssaoProps.Falloff, 0.001f, 0.f, 5.0f);
-    ImGui::DragFloat("StrengthFactor", &ssaoProps.StrengthFactor, 0.01f, 0.1f, 5.f);
-    ImGui::DragFloat("ContrastFactor", &ssaoProps.ContrastFactor, 0.01f, 0.1f, 5.f);
-    ImGui::DragFloat("Threshold", &ssaoProps.Threshold, 0.0005f, 0.f, 1.f);
+
+    if (ImGui::BeginTable("SSAO Properties", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+    {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Radius");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##Radius", &ssaoProps.Radius, 0.01f, 0.f, 50.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("FallOff");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##FallOff", &ssaoProps.Falloff, 0.001f, 0.f, 5.0f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("StrengthFactor");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##StrengthFactor", &ssaoProps.StrengthFactor, 0.01f, 0.1f, 5.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("ContrastFactor");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##ContrastFactor", &ssaoProps.ContrastFactor, 0.01f, 0.1f, 5.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Threshold");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##Threshold", &ssaoProps.Threshold, 0.0005f, 0.f, 1.f);
+        ImGui::PopItemWidth();
+
+        ImGui::EndTable();
+    }
 }
 
 void EditSSRProperty(std::any& property)
 {
     auto& ssrProps = std::any_cast<SSRPassProperty&>(property);
-    ImGui::DragFloat("MaxThickness", &ssrProps.MaxThickness, 0.01f, 0.01f, 10.f);
-    ImGui::DragFloat("StepSize", &ssrProps.StepSize, 0.01f, 0.01f, 10.f);
-    ImGui::DragFloat("MaxRayCount", &ssrProps.MaxRayCount, 1.f, 32.f, 200.f);
-    ImGui::DragFloat("ScreenFade", &ssrProps.ScreenFade, 0.01f, 0.01f, 10.f);
+
+    if (ImGui::BeginTable("SSR Properties", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+    {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Max Thickness");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##MaxThickness", &ssrProps.MaxThickness, 0.01f, 0.01f, 10.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Step Size");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##StepSize", &ssrProps.StepSize, 0.01f, 0.01f, 10.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Max Ray Count");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##MaxRayCount", &ssrProps.MaxRayCount, 1.f, 32.f, 200.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Screen Fade");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##ScreenFade", &ssrProps.ScreenFade, 0.01f, 0.01f, 10.f);
+        ImGui::PopItemWidth();
+
+        ImGui::EndTable();
+    }
 }
 
 void EditParallaxMappingProperty(std::any& property)
 {
     auto& parallaxProps = std::any_cast<ParallaxMappingProperty&>(property);
-    ImGui::DragFloat("HeightScale", &parallaxProps.HeightScale, 0.001f, 0.0f, 5.f);
-    ImGui::DragFloat("MipBias", &parallaxProps.MipBias, 0.01f, 0.f, 15.f);
+
+    if (ImGui::BeginTable("Parallax Mapping Properties", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+    {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Height Scale");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##HeightScale", &parallaxProps.HeightScale, 0.001f, 0.0f, 5.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Mip Bias");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##MipBias", &parallaxProps.MipBias, 0.01f, 0.f, 15.f);
+        ImGui::PopItemWidth();
+
+        ImGui::EndTable();
+    }
 }
 void EditVolumetricFogProperty(std::any& property)
 {
     auto& fogProperty = std::any_cast<VolumetricFogProperty&>(property);
-    ImGui::DragFloat("FogAnisotropy", &fogProperty.FogAnisotropy, 0.001f, 0.001f, 1.f);
-    ImGui::DragFloat("LightShaftAnisotropy", &fogProperty.LightShaftAnisotropy, 0.001f, 0.001f, 1.f);
-    ImGui::DragFloat("Density", &fogProperty.Density, 0.01f, 0.1f, 10.f);
-    ImGui::DragFloat("Strength", &fogProperty.Strength, 0.1f, 1.f, 100.f);
-    ImGui::DragFloat("BlendWithScene", &fogProperty.BlendWithScene, 0.001f, 0.001f, 1.f);
-    ImGui::DragFloat("BlendWithPrevFrame", &fogProperty.BlendWithPrevFrame, 0.001f, 0.001f, 1.f);
-    ImGui::DragFloat("CustomFar", &fogProperty.CustomFar, 1.f, 1.f, 1000.f);
-    ImGui::DragFloat("FogIntensity", &fogProperty.FogIntensity, 0.01f, 0.f, 5.f);
-    ImGui::DragFloat("LightShaftIntensity", &fogProperty.LightShaftIntensity, 0.01f, 0.f, 5.f);
+
+    if (ImGui::BeginTable("Volumetric Fog Properties", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+    {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Custom Far");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##CustomFar", &fogProperty.CustomFar, 1.f, 1.f, 1000.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Fog Anisotropy");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##FogAnisotropy", &fogProperty.FogAnisotropy, 0.001f, 0.001f, 1.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Light Shaft Anisotropy");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##LightShaftAnisotropy", &fogProperty.LightShaftAnisotropy, 0.001f, 0.001f, 1.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Density");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##Density", &fogProperty.Density, 0.01f, 0.1f, 10.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Strength");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##Strength", &fogProperty.Strength, 0.1f, 1.f, 100.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Blend With Scene");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##BlendWithScene", &fogProperty.BlendWithScene, 0.001f, 0.001f, 1.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Blend With Prev Frame");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##BlendWithPrevFrame", &fogProperty.BlendWithPrevFrame, 0.001f, 0.001f, 1.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Fog Intensity");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##FogIntensity", &fogProperty.FogIntensity, 0.01f, 0.f, 5.f);
+        ImGui::PopItemWidth();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        CenterText("Light Shaft Intensity");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushItemWidth(-FLT_MIN);
+        ImGui::DragFloat("##LightShaftIntensity", &fogProperty.LightShaftIntensity, 0.01f, 0.f, 5.f);
+        ImGui::PopItemWidth();
+
+        ImGui::EndTable();
+    }
 }
 
 void EditorRenderPassData::OnFrameRender()
 {
-    auto& renderPassProperties = UmGraphics.GetRenderPassProperties();
-
-    for (auto& [sceneName, properties] : renderPassProperties)
+    if (ImGui::TreeNodeEx("Properties"))
     {
-        if (ImGui::TreeNodeEx(sceneName.c_str()))
+        auto& renderPassProperties = UmGraphics.GetRenderPassProperties();
+        for (auto& [passName, property] : renderPassProperties)
         {
-            for (auto& [passName, pair] : properties)
+            if (ImGui::TreeNodeEx(passName.c_str()))
             {
-                if (ImGui::TreeNodeEx(passName.c_str()))
+                if (property.type() == typeid(ShadowPassProperty))
                 {
-                    auto& [property, images] = pair;
-                    
-                    if (ImGui::TreeNodeEx("Properties"))
-                    {
-                        if (property.type() == typeid(ShadowPassProperty))
-                        {                            
-                            EditShadowProperty(property);
-                        }
-                        else if (property.type() == typeid(BloomPassProperty))
-                        {
-                            EditBloomProperty(property);
-                        }
-                        else if (property.type() == typeid(ToneMappingProperty))
-                        {
-                            EditToneMappingProperty(property);
-                        }
-                        else if (property.type() == typeid(SSAOPassProperty))
-                        {
-                            EditSSAOProperty(property);
-                        }
-                        else if (property.type() == typeid(SSRPassProperty))
-                        {
-                            EditSSRProperty(property);
-                        }
-                        else if (property.type() == typeid(ParallaxMappingProperty))
-                        {
-                            EditParallaxMappingProperty(property);
-                        }
-                        else if (property.type() == typeid(VolumetricFogProperty))
-                        {
-                            EditVolumetricFogProperty(property);
-                        }
-                        ImGui::TreePop();
-                    }
+                    EditShadowProperty(property);
+                }
+                else if (property.type() == typeid(BloomPassProperty))
+                {
+                    EditBloomProperty(property);
+                }
+                else if (property.type() == typeid(ToneMappingProperty))
+                {
+                    EditToneMappingProperty(property);
+                }
+                else if (property.type() == typeid(SSAOPassProperty))
+                {
+                    EditSSAOProperty(property);
+                }
+                else if (property.type() == typeid(SSRPassProperty))
+                {
+                    EditSSRProperty(property);
+                }
+                else if (property.type() == typeid(ParallaxMappingProperty))
+                {
+                    EditParallaxMappingProperty(property);
+                }
+                else if (property.type() == typeid(VolumetricFogProperty))
+                {
+                    EditVolumetricFogProperty(property);
+                }
+                ImGui::TreePop();
+            }
+        }
+        ImGui::TreePop();
+    }
 
-                    if (ImGui::TreeNodeEx("Images"))
+    if (ImGui::TreeNodeEx("Images"))
+    {
+        const auto& renderPassImages = UmGraphics.GetRenderPassImages();
+        for (const auto& [sceneName, passes] : renderPassImages)
+        {
+            if (ImGui::TreeNodeEx((sceneName).c_str()))
+            {
+                for (const auto& [passName, images] : passes)
+                {
+                    if (ImGui::TreeNodeEx(passName.c_str()))
                     {
                         for (const auto& [dataName, handles] : images)
                         {
@@ -135,19 +389,21 @@ void EditorRenderPassData::OnFrameRender()
                                 for (const auto& handle : handles)
                                 {
                                     ImVec2 availSize = ImGui::GetContentRegionAvail();
-                                    ImGui::Image((ImTextureID)handle.ptr, ImVec2(availSize.x * 0.5f, availSize.x * 0.5f));
+                                    ImGui::Image((ImTextureID)handle.ptr,
+                                                 ImVec2(availSize.x * 0.5f, availSize.x * 0.5f));
                                 }
                                 ImGui::TreePop();
                             }
                         }
                         ImGui::TreePop();
                     }
-                    ImGui::TreePop();
                 }
+                ImGui::TreePop();
             }
-            ImGui::TreePop();
         }
+        ImGui::TreePop();
     }
+
     if (ImGui::Button("SaveData"))
     {
         std::vector<std::pair<LPCWSTR, LPCWSTR>> filters = {{L"Save Files (*.inl)", L"*.inl\0\0"}};

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderPassDataHelper.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GraphicsCore/RenderPassDataHelper.h
@@ -3,75 +3,73 @@
 // ShadowPassProperty를 문자열로 변환
 inline void SerializeShadowProperty(std::ostream& os, const ShadowPassProperty& prop)
 {
-	os << "        Type = ShadowPassProperty\n";
-	os << "        NearPlane = " << prop.NearPlane << "\n";
-	os << "        FarPlane = " << prop.FarPlane << "\n";
-	os << "        SplitFactor = " << prop.SplitFactor << "\n";
-    os << "        Offset1 = " << prop.Offset1 << "\n";
-    os << "        Offset2 = " << prop.Offset2 << "\n";
+	os << "    Type = ShadowPassProperty\n";
+	os << "    NearPlane = " << prop.NearPlane << "\n";
+	os << "    FarPlane = " << prop.FarPlane << "\n";
+	os << "    SplitFactor = " << prop.SplitFactor << "\n";
 }
 
 // BloomPassProperty를 문자열로 변환
 inline void SerializeBloomProperty(std::ostream& os, const BloomPassProperty& prop)
 {
-	os << "        Type = BloomPassProperty\n";
-	os << "        Threshold = " << prop.Threshold << "\n";
-	os << "        Intensity = " << prop.Intensity << "\n";
-	os << "        BloomKnee = " << prop.BloomKnee << "\n";
+	os << "    Type = BloomPassProperty\n";
+	os << "    Threshold = " << prop.Threshold << "\n";
+	os << "    Intensity = " << prop.Intensity << "\n";
+	os << "    BloomKnee = " << prop.BloomKnee << "\n";
 }
 
 // ToneMappingProperty를 문자열로 변환
 inline void SerializeToneMappingProperty(std::ostream& os, const ToneMappingProperty& prop)
 {
-	os << "        Type = ToneMappingProperty\n";
-	os << "        Exposure = " << prop.Exposure << "\n";
-	os << "        Saturation = " << prop.Saturation << "\n";
-	os << "        Contrast = " << prop.Contrast << "\n";
-	os << "        WhiteBalance = " << prop.WhiteBalance.x << " " << prop.WhiteBalance.y << " " << prop.WhiteBalance.z << "\n";
+	os << "    Type = ToneMappingProperty\n";
+	os << "    Exposure = " << prop.Exposure << "\n";
+	os << "    Saturation = " << prop.Saturation << "\n";
+	os << "    Contrast = " << prop.Contrast << "\n";
+	os << "    WhiteBalance = " << prop.WhiteBalance.x << " " << prop.WhiteBalance.y << " " << prop.WhiteBalance.z << "\n";
 }
 
 // SSAOPassProperty를 문자열로 변환
 inline void SerializeSSAOPassProperty(std::ostream& os, const SSAOPassProperty& prop)
 {
-    os << "        Type = SSAOPassProperty\n";
-    os << "        Radius = " << prop.Radius << "\n";
-    os << "        Falloff = " << prop.Falloff << "\n";
-    os << "        StrengthFactor = " << prop.StrengthFactor << "\n";
-    os << "        ContrastFactor = " << prop.ContrastFactor << "\n";
-    os << "        Threshold = " << prop.Threshold << "\n";
+    os << "    Type = SSAOPassProperty\n";
+    os << "    Radius = " << prop.Radius << "\n";
+    os << "    Falloff = " << prop.Falloff << "\n";
+    os << "    StrengthFactor = " << prop.StrengthFactor << "\n";
+    os << "    ContrastFactor = " << prop.ContrastFactor << "\n";
+    os << "    Threshold = " << prop.Threshold << "\n";
 }
 
 // SSRPassProperty를 문자열로 변환
 inline void SerializeSSRPassProperty(std::ostream& os, const SSRPassProperty& prop)
 {
-    os << "        Type = SSRPassProperty\n";
-    os << "        MaxThickness = " << prop.MaxThickness   << "\n";
-    os << "        StepSize = " << prop.StepSize  << "\n";
-    os << "        MaxRayCount = " << prop.MaxRayCount << "\n";
-    os << "        ScreenFade = " << prop.ScreenFade << "\n";
+    os << "    Type = SSRPassProperty\n";
+    os << "    MaxThickness = " << prop.MaxThickness   << "\n";
+    os << "    StepSize = " << prop.StepSize  << "\n";
+    os << "    MaxRayCount = " << prop.MaxRayCount << "\n";
+    os << "    ScreenFade = " << prop.ScreenFade << "\n";
 }
 
 // ParallaxMappingProperty를 문자열로 변환
 inline void SerializeParallaxMappingProperty(std::ostream& os, const ParallaxMappingProperty& prop)
 {
-    os << "        Type = ParallaxMappingProperty\n";
-    os << "        HeightScale = " << prop.HeightScale << "\n";
+    os << "    Type = ParallaxMappingProperty\n";
+    os << "    HeightScale = " << prop.HeightScale << "\n";
 }
 
 // VolumetricFogProperty를 문자열로 변환
 inline void SerializeVolumetricFogProperty(std::ostream& os, const VolumetricFogProperty& prop)
 {
-    os << "        Type = VolumetricFogProperty\n";
-    os << "        FogAnisotropy = " << prop.FogAnisotropy << "\n";
-    os << "        LightShaftAnisotropy = " << prop.LightShaftAnisotropy << "\n";
-    os << "        Density = " << prop.Density << "\n";
-    os << "        Strength = " << prop.Strength << "\n";
-    os << "        BlendWithScene = " << prop.BlendWithScene << "\n";
-    os << "        BlendWithPrevFrame = " << prop.BlendWithPrevFrame << "\n";
-    os << "        CustomNear = " << prop.CustomNear << "\n";
-    os << "        CustomFar = " << prop.CustomFar << "\n";
-    os << "        FogIntensity = " << prop.FogIntensity << "\n";
-    os << "        LightShaftIntensity = " << prop.LightShaftIntensity << "\n";
+    os << "    Type = VolumetricFogProperty\n";
+    os << "    FogAnisotropy = " << prop.FogAnisotropy << "\n";
+    os << "    LightShaftAnisotropy = " << prop.LightShaftAnisotropy << "\n";
+    os << "    Density = " << prop.Density << "\n";
+    os << "    Strength = " << prop.Strength << "\n";
+    os << "    BlendWithScene = " << prop.BlendWithScene << "\n";
+    os << "    BlendWithPrevFrame = " << prop.BlendWithPrevFrame << "\n";
+    os << "    CustomNear = " << prop.CustomNear << "\n";
+    os << "    CustomFar = " << prop.CustomFar << "\n";
+    os << "    FogIntensity = " << prop.FogIntensity << "\n";
+    os << "    LightShaftIntensity = " << prop.LightShaftIntensity << "\n";
 }
 
 
@@ -86,8 +84,6 @@ inline void DeserializeShadowProperty(std::istream& is, ShadowPassProperty& prop
 		if (key == "NearPlane") ss >> prop.NearPlane;
 		else if (key == "FarPlane") ss >> prop.FarPlane;
 		else if (key == "SplitFactor") ss >> prop.SplitFactor;
-        else if (key == "Offset1") ss >> prop.Offset1;
-        else if (key == "Offset2") ss >> prop.Offset2;
 	}
 }
 
@@ -222,138 +218,152 @@ inline void SaveRenderPassData(const std::string& filePath)
 	}
 
 	auto& renderPassProperties = UmGraphics.GetRenderPassProperties();
+	for (const auto& [passName, property] : renderPassProperties)
+	{		
+		outFile << "Pass " << passName << "\n{\n";
 
-	for (const auto& [sceneName, properties] : renderPassProperties)
-	{
-		outFile << "Scene " << sceneName << "\n{\n";
-		for (const auto& [passName, pair] : properties)
-		{
-			outFile << "    Pass " << passName << "\n    {\n";
-			const auto& property = pair.first;
-
-			if (property.type() == typeid(ShadowPassProperty))
-			{
-				SerializeShadowProperty(outFile, std::any_cast<const ShadowPassProperty&>(property));
-			}
-			else if (property.type() == typeid(BloomPassProperty))
-			{
-				SerializeBloomProperty(outFile, std::any_cast<const BloomPassProperty&>(property));
-			}
-			else if (property.type() == typeid(ToneMappingProperty))
-			{
-				SerializeToneMappingProperty(outFile, std::any_cast<const ToneMappingProperty&>(property));
-			}
-            else if (property.type() == typeid(SSAOPassProperty))
-            {
-                SerializeSSAOPassProperty(outFile, std::any_cast<const SSAOPassProperty&>(property));
-            }
-            else if (property.type() == typeid(SSRPassProperty))
-            {
-                SerializeSSRPassProperty(outFile, std::any_cast<const SSRPassProperty&>(property));
-            }
-            else if (property.type() == typeid(ParallaxMappingProperty))
-            {
-                SerializeParallaxMappingProperty(outFile, std::any_cast<const ParallaxMappingProperty&>(property));
-            }
-            else if (property.type() == typeid(VolumetricFogProperty))
-            {
-                SerializeVolumetricFogProperty(outFile, std::any_cast<const VolumetricFogProperty&>(property));
-            }
-			outFile << "    }\n";
-		}
-		outFile << "}\n\n";
-	}
+        if (property.type() == typeid(ShadowPassProperty))
+        {
+            SerializeShadowProperty(outFile, std::any_cast<const ShadowPassProperty&>(property));
+        }
+        else if (property.type() == typeid(BloomPassProperty))
+        {
+            SerializeBloomProperty(outFile, std::any_cast<const BloomPassProperty&>(property));
+        }
+        else if (property.type() == typeid(ToneMappingProperty))
+        {
+            SerializeToneMappingProperty(outFile, std::any_cast<const ToneMappingProperty&>(property));
+        }
+        else if (property.type() == typeid(SSAOPassProperty))
+        {
+            SerializeSSAOPassProperty(outFile, std::any_cast<const SSAOPassProperty&>(property));
+        }
+        else if (property.type() == typeid(SSRPassProperty))
+        {
+            SerializeSSRPassProperty(outFile, std::any_cast<const SSRPassProperty&>(property));
+        }
+        else if (property.type() == typeid(ParallaxMappingProperty))
+        {
+            SerializeParallaxMappingProperty(outFile, std::any_cast<const ParallaxMappingProperty&>(property));
+        }
+        else if (property.type() == typeid(VolumetricFogProperty))
+        {
+            SerializeVolumetricFogProperty(outFile, std::any_cast<const VolumetricFogProperty&>(property));
+        }
+        outFile << "}\n";
+    }
 }
 
 inline void LoadRenderPassData(const std::string& filePath)
 {
-	std::ifstream inFile(filePath);
-	if (!inFile.is_open())
-	{
-		return;
-	}
-
-	auto& renderPassProperties = UmGraphics.GetRenderPassProperties();
-	std::string line, keyword, name;
-
-	while (std::getline(inFile, line))
-	{
-		std::stringstream ss(line);
-		ss >> keyword >> name;
-
-		if (keyword == "Scene")
-		{
-			std::string currentSceneName = name;
-			std::getline(inFile, line); // '{' 라인 스킵
-
-			while (std::getline(inFile, line) && line.find('}') == std::string::npos)
-			{
-				std::stringstream pass_ss(line);
-				pass_ss >> keyword >> name;
-
-				if (keyword == "Pass")
-				{
-					std::string currentPassName = name;
-					std::getline(inFile, line); // '{' 라인 스킵
-
-					// Pass에 해당하는 속성 찾기
-					if (renderPassProperties.count(currentSceneName) && renderPassProperties[currentSceneName].count(currentPassName))
-					{
-						auto& property = renderPassProperties[currentSceneName][currentPassName].first;
-
-						// 타입 확인 및 복원
-						std::string typeLine;
-						std::getline(inFile, typeLine);
-						std::stringstream type_ss(typeLine);
-						type_ss >> keyword >> name >> name; // "Type = ShadowPassProperty"
-
-						if (name == "ShadowPassProperty" && property.type() == typeid(ShadowPassProperty))
-						{
-							DeserializeShadowProperty(inFile, std::any_cast<ShadowPassProperty&>(property));
-						}
-						else if (name == "BloomPassProperty" && property.type() == typeid(BloomPassProperty))
-						{
-							DeserializeBloomProperty(inFile, std::any_cast<BloomPassProperty&>(property));
-						}
-						else if (name == "ToneMappingProperty" && property.type() == typeid(ToneMappingProperty))
-						{
-							DeserializeToneMappingProperty(inFile, std::any_cast<ToneMappingProperty&>(property));
-						}
-                        else if (name == "SSAOPassProperty" && property.type() == typeid(SSAOPassProperty))
-                        {
-                            DeserializeSSAOPassProperty(inFile, std::any_cast<SSAOPassProperty&>(property));
-                        }
-                        else if (name == "SSRPassProperty" && property.type() == typeid(SSRPassProperty))
-                        {
-                            DeserializeSSRPassProperty(inFile, std::any_cast<SSRPassProperty&>(property));
-                        }
-                        else if (name == "ParallaxMappingProperty" && property.type() == typeid(ParallaxMappingProperty))
-                        {
-                            DeserializeParallaxMappingProperty(inFile, std::any_cast<ParallaxMappingProperty&>(property));
-                        }
-                        else if (name == "VolumetricFogProperty" && property.type() == typeid(VolumetricFogProperty))
-                        {
-                            DeserializeVolumetricFogProperty(inFile, std::any_cast<VolumetricFogProperty&>(property));
-                        }
-					}
-				}
-			}
-		}
-	}
-
-    auto editor = renderPassProperties.find("Editor");
-    if (editor != renderPassProperties.end())
+    std::ifstream inFile(filePath);
+    if (!inFile.is_open())
     {
-        auto game = renderPassProperties.find("Game");
+        return;
+    }
 
-        if (game != renderPassProperties.end())
+    // --- Format Detection ---
+    bool isOldFormat = false;
+    std::string firstLine;
+    std::streampos originalPos = inFile.tellg();
+    while (std::getline(inFile, firstLine))
+    {
+        if (!firstLine.empty())
         {
-            for (auto& [passName, pair] : game->second)
+            std::stringstream ss(firstLine);
+            std::string keyword;
+            ss >> keyword;
+            if (keyword == "Scene")
             {
-                auto editorPair = editor->second.find(passName);
-                if (editorPair != editor->second.end())
+                isOldFormat = true;
+            }
+            break;
+        }
+    }
+    inFile.clear();
+    inFile.seekg(originalPos);
+    // -- End of Format Detection --
+
+    auto& renderPassProperties = UmGraphics.GetRenderPassProperties();
+    std::string line, keyword, name;
+
+    if (isOldFormat)
+    {
+        // --- Old Format Parsing Logic (with "Scene Game" filter) ---
+        while (std::getline(inFile, line))
+        {
+            std::stringstream ss(line);
+            ss >> keyword >> name;
+
+            if (keyword == "Scene")
+            {
+                bool isGameScene = (name == "Game");
+                std::getline(inFile, line); // Skip '{' line
+
+                while (std::getline(inFile, line) && line.find('}') == std::string::npos)
                 {
-                    pair = editorPair->second;
+                    std::stringstream pass_ss(line);
+                    pass_ss >> keyword >> name;
+
+                    if (keyword == "Pass")
+                    {
+                        std::string currentPassName = name;
+                        std::getline(inFile, line); // Skip '{' line
+
+                        if (isGameScene && renderPassProperties.count(currentPassName))
+                        {
+                            auto& property = renderPassProperties.at(currentPassName);
+                            std::string typeLine, typeName;
+                            std::getline(inFile, typeLine);
+                            std::stringstream type_ss(typeLine);
+                            type_ss >> keyword >> name >> typeName;
+
+                            if (typeName == "ShadowPassProperty") DeserializeShadowProperty(inFile, std::any_cast<ShadowPassProperty&>(property));
+                            else if (typeName == "BloomPassProperty") DeserializeBloomProperty(inFile, std::any_cast<BloomPassProperty&>(property));
+                            else if (typeName == "ToneMappingProperty") DeserializeToneMappingProperty(inFile, std::any_cast<ToneMappingProperty&>(property));
+                            else if (typeName == "SSAOPassProperty") DeserializeSSAOPassProperty(inFile, std::any_cast<SSAOPassProperty&>(property));
+                            else if (typeName == "SSRPassProperty") DeserializeSSRPassProperty(inFile, std::any_cast<SSRPassProperty&>(property));
+                            else if (typeName == "ParallaxMappingProperty") DeserializeParallaxMappingProperty(inFile, std::any_cast<ParallaxMappingProperty&>(property));
+                            else if (typeName == "VolumetricFogProperty") DeserializeVolumetricFogProperty(inFile, std::any_cast<VolumetricFogProperty&>(property));
+                        }
+                        else
+                        {
+                            // Skip content of non-game scene passes or unknown passes
+                            while (std::getline(inFile, line) && line.find('}') == std::string::npos) {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        // --- New Format Parsing Logic ---
+        while (std::getline(inFile, line))
+        {
+            std::stringstream ss(line);
+            ss >> keyword >> name;
+
+            if (keyword == "Pass")
+            {
+                std::string currentPassName = name;
+                std::getline(inFile, line); // Skip '{' line
+
+                if (renderPassProperties.count(currentPassName))
+                {
+                    auto& property = renderPassProperties.at(currentPassName);
+                    std::string typeLine, typeName;
+                    std::getline(inFile, typeLine);
+                    std::stringstream type_ss(typeLine);
+                    type_ss >> keyword >> name >> typeName;
+
+                    if (typeName == "ShadowPassProperty") DeserializeShadowProperty(inFile, std::any_cast<ShadowPassProperty&>(property));
+                    else if (typeName == "BloomPassProperty") DeserializeBloomProperty(inFile, std::any_cast<BloomPassProperty&>(property));
+                    else if (typeName == "ToneMappingProperty") DeserializeToneMappingProperty(inFile, std::any_cast<ToneMappingProperty&>(property));
+                    else if (typeName == "SSAOPassProperty") DeserializeSSAOPassProperty(inFile, std::any_cast<SSAOPassProperty&>(property));
+                    else if (typeName == "SSRPassProperty") DeserializeSSRPassProperty(inFile, std::any_cast<SSRPassProperty&>(property));
+                    else if (typeName == "ParallaxMappingProperty") DeserializeParallaxMappingProperty(inFile, std::any_cast<ParallaxMappingProperty&>(property));
+                    else if (typeName == "VolumetricFogProperty") DeserializeVolumetricFogProperty(inFile, std::any_cast<VolumetricFogProperty&>(property));
                 }
             }
         }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/BlendPass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/BlendPass.cpp
@@ -23,7 +23,7 @@ void BlendPass::Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechni
 
 void BlendPass::AddRenderPassDatas(std::string_view sceneName)
 {
-    Global::renderPassDatas->AddRenderPassProperty(sceneName, "ToneMappingPass", ToneMappingProperty({{1.f, 1.f, 1.f}, 1.f, 1.f, 1.f}));
+    Global::renderPassDatas->AddRenderPassProperty("ToneMappingPass", ToneMappingProperty({{1.f, 1.f, 1.f}, 1.f, 1.f, 1.f}));
 }
 
 void BlendPass::Begin(ID3D12GraphicsCommandList* commandList)
@@ -43,7 +43,7 @@ void BlendPass::Draw(ID3D12GraphicsCommandList* commandList)
     commandList->SetPipelineState(_pipelineState.Get());
     commandList->SetGraphicsRootSignature(_fx.GetRootSignature());
 
-    const auto& toneMappingProperty = std::any_cast<const ToneMappingProperty&>(_ownerScene->GetRenderPassProperty("ToneMappingPass"));
+    const auto& toneMappingProperty = std::any_cast<const ToneMappingProperty&>(Global::renderPassDatas->GetRenderPassProperty("ToneMappingPass"));
 
     commandList->SetGraphicsRoot32BitConstants(_fx.GetRootParameterIndex("bit32_6_tonMappingProperty"), 6, &toneMappingProperty, 0);
     commandList->SetGraphicsRootDescriptorTable(_fx.GetRootParameterIndex("screenTexture"), _meshRenderTarget->GetSRVHandle());

--- a/Source/GA6thFinal_Framework/GraphicsEngine/BrightExtractPass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/BrightExtractPass.cpp
@@ -46,7 +46,7 @@ void BrightExtractPass::AddRenderPassDatas(std::string_view sceneName)
     srvDesc.Texture2D.MipLevels              = 1;
     device->CreateShaderResourceView(_finalTexture.Get(), &srvDesc, _finalHandle.CPU);
 
-    Global::renderPassDatas->AddRenderPassProperty(sceneName, "BloomPass", BloomPassProperty({1.f, 1.f, 0.2f}));
+    Global::renderPassDatas->AddRenderPassProperty("BloomPass", BloomPassProperty({1.f, 1.f, 0.2f}));
     Global::renderPassDatas->AddRenderPassImage(sceneName, "BloomPass", "BrightExtractTexture", _finalHandle.GPU);
 }
 
@@ -65,7 +65,7 @@ void BrightExtractPass::Draw(ID3D12GraphicsCommandList* commandList)
     PostProcessData postProcessData{.ScreenSize      = {(float)resolution.cx, (float)resolution.cy},
                                     .PostProcessMask = PostProcess::BLOOM};
 
-    const auto& bloomProperty = std::any_cast<const BloomPassProperty&>(_ownerScene->GetRenderPassProperty("BloomPass"));
+    const auto& bloomProperty = std::any_cast<const BloomPassProperty&>(Global::renderPassDatas->GetRenderPassProperty("BloomPass"));
 
     auto customDepthTarget = Global::multiRenderTargetManager->GetRenderTarget("CustomDepth");
 

--- a/Source/GA6thFinal_Framework/GraphicsEngine/DownAndUpSamplingPass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/DownAndUpSamplingPass.cpp
@@ -67,7 +67,7 @@ void DownAndUpSamplingPass::AddRenderPassDatas(std::string_view sceneName)
     srvDesc.Texture2D.MipLevels             = 1;
     device->CreateShaderResourceView(_finalTexture.Get(), &srvDesc, _finalHandle.CPU);
 
-    Global::renderPassDatas->AddRenderPassProperty(sceneName, "BloomPass", BloomPassProperty({1.f, 1.f, 0.2f}));
+    Global::renderPassDatas->AddRenderPassProperty("BloomPass", BloomPassProperty({1.f, 1.f, 0.2f}));
     Global::renderPassDatas->AddRenderPassImage(sceneName, "BloomPass", "BloomTexture", _finalHandle.GPU);
 }
 

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Enums.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Enums.h
@@ -7,7 +7,7 @@ constexpr UINT MAX_POINT_LIGHT        = 32;
 constexpr UINT MAX_SPOT_LIGHT         = 16;
 constexpr UINT MAX_LIGHT              = MAX_DIRECTIONAL_LIGHT + MAX_POINT_LIGHT + MAX_SPOT_LIGHT;
 constexpr UINT MAX_MIPMAP_LEVEL       = 5;
-constexpr UINT MAX_CASCADES           = 4;
+constexpr UINT MAX_CASCADES           = 3;
 constexpr UINT MAX_UI_MATERIAL_DATA   = 256;
 
 // volumetric fog medium

--- a/Source/GA6thFinal_Framework/GraphicsEngine/FogCompositePass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/FogCompositePass.cpp
@@ -2,10 +2,9 @@
 #include "FogCompositePass.h"
 #include "VolumetricFogTechnique.h"
 
-FogCompositePass::~FogCompositePass() {}
+FogCompositePass::~FogCompositePass() = default;
 
-void FogCompositePass::Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique,
-                                  ID3D12GraphicsCommandList* commandList)
+void FogCompositePass::Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique, ID3D12GraphicsCommandList* commandList)
 {
     __super::Initialize(ownerScene, ownerTechnique, commandList);
     auto resolution = Global::device->GetResolution();
@@ -14,10 +13,6 @@ void FogCompositePass::Initialize(RenderScene* ownerScene, RenderTechnique* owne
     InitShaderAndPSO();
     _volumTech = dynamic_cast<VolumetricFogTechnique*>(ownerTechnique);
 }
-
-void FogCompositePass::Update(ID3D12GraphicsCommandList* commandList, const float deltaTime) {}
-
-void FogCompositePass::Begin(ID3D12GraphicsCommandList* commandList) {}
 
 void FogCompositePass::Draw(ID3D12GraphicsCommandList* commandList) 
 {
@@ -48,10 +43,6 @@ void FogCompositePass::Draw(ID3D12GraphicsCommandList* commandList)
 
     Global::multiRenderTargetManager->ReturnRenderTarget(renderTarget);
 }
-
-void FogCompositePass::End(ID3D12GraphicsCommandList* commandList) {}
-
-void FogCompositePass::AddRenderPassDatas(std::string_view sceneName) {}
 
 void FogCompositePass::InitShaderAndPSO()
 {

--- a/Source/GA6thFinal_Framework/GraphicsEngine/FogCompositePass.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/FogCompositePass.h
@@ -8,13 +8,8 @@ public:
     virtual ~FogCompositePass();
 
 public:
-    void Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique,
-                    ID3D12GraphicsCommandList* commandList) override;
-    void Update(ID3D12GraphicsCommandList* commandList, const float deltaTime) override;
-    void Begin(ID3D12GraphicsCommandList* commandList) override;
+    void Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique, ID3D12GraphicsCommandList* commandList) override;
     void Draw(ID3D12GraphicsCommandList* commandList) override;
-    void End(ID3D12GraphicsCommandList* commandList) override;
-    void AddRenderPassDatas(std::string_view sceneName) override;
 
 private:
     void InitShaderAndPSO();

--- a/Source/GA6thFinal_Framework/GraphicsEngine/FogLightAccmulatePass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/FogLightAccmulatePass.cpp
@@ -4,17 +4,15 @@
 #include "d3dUtil.h"
 #include "ShaderBuilder.h"
 
-FogLightAccmulatePass::~FogLightAccmulatePass() {}
+FogLightAccmulatePass::~FogLightAccmulatePass() = default;
 
 void FogLightAccmulatePass::Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique,
                                        ID3D12GraphicsCommandList* commandList)
 {
-    __super::Initialize(ownerScene, ownerTechnique, commandList);
+    RenderPass::Initialize(ownerScene, ownerTechnique, commandList);
     InitShaderAndPSO();
     _volumTech = dynamic_cast<VolumetricFogTechnique*>(ownerTechnique);
 }
-
-void FogLightAccmulatePass::Update(ID3D12GraphicsCommandList* commandList, const float deltaTime) {}
 
 void FogLightAccmulatePass::Begin(ID3D12GraphicsCommandList* commandList) 
 {
@@ -35,10 +33,6 @@ void FogLightAccmulatePass::Draw(ID3D12GraphicsCommandList* commandList)
                                                finalaccumulateTex->GetUAVHandle());
     commandList->Dispatch(d3dUtil::Ceil(VOXEL_VOLUME_SIZEX , 8), d3dUtil::Ceil(VOXEL_VOLUME_SIZEY ,8), 1);
 }
-
-void FogLightAccmulatePass::End(ID3D12GraphicsCommandList* commandList) {}
-
-void FogLightAccmulatePass::AddRenderPassDatas(std::string_view sceneName) {}
 
 void FogLightAccmulatePass::InitShaderAndPSO()
 {

--- a/Source/GA6thFinal_Framework/GraphicsEngine/FogLightAccmulatePass.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/FogLightAccmulatePass.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include "RenderPass.h"
 class VolumetricFogTechnique;
+
 class FogLightAccmulatePass : public RenderPass
 {
 public:
@@ -8,13 +9,9 @@ public:
     virtual ~FogLightAccmulatePass();
 
 public:
-    void Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique,
-                    ID3D12GraphicsCommandList* commandList) override;
-    void Update(ID3D12GraphicsCommandList* commandList, const float deltaTime) override;
+    void Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique, ID3D12GraphicsCommandList* commandList) override;
     void Begin(ID3D12GraphicsCommandList* commandList) override;
     void Draw(ID3D12GraphicsCommandList* commandList) override;
-    void End(ID3D12GraphicsCommandList* commandList) override;
-    void AddRenderPassDatas(std::string_view sceneName) override;
 
 private:
     void InitShaderAndPSO();

--- a/Source/GA6thFinal_Framework/GraphicsEngine/FogLightInjectionPass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/FogLightInjectionPass.cpp
@@ -58,7 +58,7 @@ void FogLightInjectionPass::AddRenderPassDatas(std::string_view sceneName)
     property.CustomFar            = 1000.f;
     property.FogIntensity         = 1.f;
     property.LightShaftIntensity  = 1.f;
-    Global::renderPassDatas->AddRenderPassProperty(sceneName, "VolumetricFogData", property);
+    Global::renderPassDatas->AddRenderPassProperty("VolumetricFogData", property);
 }
 
 void FogLightInjectionPass::InitShaderAndPSO()

--- a/Source/GA6thFinal_Framework/GraphicsEngine/ForwardPBRLitPass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/ForwardPBRLitPass.cpp
@@ -135,8 +135,7 @@ void ForwardPBRLitPass::Draw(ID3D12GraphicsCommandList* commandList)
     auto  cameraData             = _ownerScene->_cameraBuffer->GetGPUVirtualAddress();
     auto  lightData              = _ownerScene->_lightBuffer->GetGPUVirtualAddress();
     auto& frameResource          = _ownerScene->_frameResources[currentBackBufferIndex];
-    
-    auto shadowMapPass = _ownerTechnique->GetRenderPass<ShadowMapPass>();
+    auto  shadowMapPass          = _ownerTechnique->GetRenderPass<ShadowMapPass>();
 
     if (nullptr == shadowMapPass)
         return;
@@ -222,7 +221,7 @@ void ForwardPBRLitPass::End(ID3D12GraphicsCommandList* commandList)
 
 void ForwardPBRLitPass::DrawMeshes(ID3D12GraphicsCommandList* commandList, MeshType meshType, CullMode cullMode)
 {
-    const auto& parallaxMappingProperty = std::any_cast<const ParallaxMappingProperty&>(_ownerScene->GetRenderPassProperty("G-BufferPass"));
+    const auto& parallaxMappingProperty = std::any_cast<const ParallaxMappingProperty&>(Global::renderPassDatas->GetRenderPassProperty("G-BufferPass"));
 
     switch (meshType)
     {

--- a/Source/GA6thFinal_Framework/GraphicsEngine/GBufferPass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/GBufferPass.cpp
@@ -37,7 +37,7 @@ void GBufferPass::AddRenderPassDatas(std::string_view sceneName)
     Global::renderPassDatas->AddRenderPassImage(sceneName, "G-BufferPass", "ORM", _gBufferRenderTargets[2]->GetSRVHandle());
     Global::renderPassDatas->AddRenderPassImage(sceneName, "G-BufferPass", "Emissive", _gBufferRenderTargets[3]->GetSRVHandle());
     
-    Global::renderPassDatas->AddRenderPassProperty(sceneName, "G-BufferPass", ParallaxMappingProperty(2.9f,0.f));
+    Global::renderPassDatas->AddRenderPassProperty("G-BufferPass", ParallaxMappingProperty(2.9f,0.f));
 }
 
 void GBufferPass::Update(ID3D12GraphicsCommandList* commadList, const float deltaTime)
@@ -196,7 +196,7 @@ void GBufferPass::InitShaderAndPSO()
 
 void GBufferPass::DrawMeshes(ID3D12GraphicsCommandList* commandList, MeshType meshType, Material::BlendModeType blendModeType, CullMode cullMode)
 {
-    const auto& parallaxMappingProperty = std::any_cast<const ParallaxMappingProperty&>(_ownerScene->GetRenderPassProperty("G-BufferPass"));
+    const auto& parallaxMappingProperty = std::any_cast<const ParallaxMappingProperty&>(Global::renderPassDatas->GetRenderPassProperty("G-BufferPass"));
 
     switch (meshType)
     {

--- a/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsCore.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsCore.cpp
@@ -75,6 +75,11 @@ RenderPassProperties& GraphicsCore::GetRenderPassProperties() const
     return _renderPassDatas->GetRenderPassProperties();
 }
 
+const RenderPassImages& GraphicsCore::GetRenderPassImages() const
+{
+    return _renderPassDatas->GetRenderPassImages();
+}
+
 SceneTransitionCore* GraphicsCore::GetSceneTransitionCore() const 
 {
     return _sceneTransitionCore;

--- a/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsCore.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/GraphicsCore.h
@@ -16,6 +16,7 @@ public:
     D3D12_CPU_DESCRIPTOR_HANDLE GetBackBufferHandle() const;
     ID3D12GraphicsCommandList*  GetCommandList() const;
     RenderPassProperties&       GetRenderPassProperties() const;
+    const RenderPassImages&     GetRenderPassImages() const;
     SceneTransitionCore*        GetSceneTransitionCore() const;
     const SIZE&                 GetResolution() const;
 

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Graphics_Structs.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Graphics_Structs.h
@@ -106,20 +106,9 @@ struct GraphicsTransform
 
 struct ShadowPassProperty
 {
-    bool operator==(const ShadowPassProperty& other) const
-    {
-        return NearPlane == other.NearPlane && 
-               FarPlane == other.FarPlane && 
-               SplitFactor == other.SplitFactor && 
-               Offset1 == other.Offset1 &&
-               Offset2 == other.Offset2;
-    }
-
     float NearPlane;
     float FarPlane;
     float SplitFactor;
-    float Offset1;
-    float Offset2;
 };
 
 struct BloomPassProperty

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Light.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Light.cpp
@@ -7,7 +7,7 @@ Light::Light()
     _data.Intensity = 1.f;
 }
 
-Light::~Light() {}
+Light::~Light() = default;
 
 void Light::SetDirectionalLight(const Vector3& color, const Vector3& ambient, const Vector3& direction,
                                 const float& intensity)

--- a/Source/GA6thFinal_Framework/GraphicsEngine/RenderPassDatas.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/RenderPassDatas.cpp
@@ -1,7 +1,2 @@
 ﻿#include "pch.h"
 #include "RenderPassDatas.h"
-
-const std::any& RenderPassDatas::GetRenderPassProperty(std::string_view sceneName, std::string_view passName) const
-{
-    return _renderPassProperties.at(sceneName.data()).at(passName.data()).first;
-}

--- a/Source/GA6thFinal_Framework/GraphicsEngine/RenderPassDatas.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/RenderPassDatas.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 
-using RenderPassDataPair = std::pair<std::any, std::unordered_map<std::string, std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>>>;
-using RenderPassProperties = std::unordered_map<std::string, std::unordered_map<std::string, RenderPassDataPair>>;
+using RenderPassProperties = std::unordered_map<std::string, std::any>;
+using RenderPassImages = std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::string, std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>>>>;
 
 class RenderPassDatas
 {
@@ -10,22 +10,22 @@ public:
     ~RenderPassDatas() = default;
 
 public:
+    const std::any&         GetRenderPassProperty(std::string_view passName) const { return _renderPassProperties.at(passName.data()); }
     RenderPassProperties&   GetRenderPassProperties() { return _renderPassProperties; }
-    const std::any&         GetRenderPassProperty(std::string_view sceneName, std::string_view passName) const;
+    const RenderPassImages& GetRenderPassImages() const { return _renderPassImages; }
 
 public:
     void AddRenderPassImage(std::string_view sceneName, std::string_view passName, std::string_view dataName, D3D12_GPU_DESCRIPTOR_HANDLE handle)
     {
-        auto& [property, handles] = _renderPassProperties[sceneName.data()][passName.data()];
-        handles[dataName.data()].push_back(handle);
+        _renderPassImages[sceneName.data()][passName.data()][dataName.data()].push_back(handle);
     }
 
-    void AddRenderPassProperty(std::string_view sceneName, std::string_view passName, std::any value)
+    void AddRenderPassProperty(std::string_view passName, std::any value)
     {
-        auto& [property, handles] = _renderPassProperties[sceneName.data()][passName.data()];
-        property                  = value;
+        _renderPassProperties.try_emplace(passName.data(), value);
     }
 
 private:
+    RenderPassImages     _renderPassImages;
     RenderPassProperties _renderPassProperties;
 };

--- a/Source/GA6thFinal_Framework/GraphicsEngine/RenderScene.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/RenderScene.cpp
@@ -28,11 +28,6 @@ D3D12_GPU_DESCRIPTOR_HANDLE RenderScene::GetFinalImage()
     return finalTarget->GetSRVHandle();
 }
 
-const std::any& RenderScene::GetRenderPassProperty(std::string_view passName) const
-{
-    return Global::renderPassDatas->GetRenderPassProperty(_name, passName);
-}
-
 SharedResource<RenderTarget> RenderScene::GetSharedRenderTarget() const
 {
     return _sharedRenderTarget[_currentFrameIndex];
@@ -314,7 +309,7 @@ void RenderScene::UpdateObject()
             continue;
         }
 
-        if (!_isDirtyFlag)
+        /*if (!_isDirtyFlag)
         {
             _isDirtyFlag = model->IsDirtyFlag() || component->IsDirtyFlag();
 
@@ -322,7 +317,7 @@ void RenderScene::UpdateObject()
             {
                 model->SetDirtyFlag(false);
             }
-        }
+        }*/
 
         const auto  type         = component->GetType();
         const auto& customDepths = component->GetCustomDepths();

--- a/Source/GA6thFinal_Framework/GraphicsEngine/RenderScene.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/RenderScene.h
@@ -19,7 +19,6 @@ public:
     std::shared_ptr<Camera>      GetCamera() const { return _camera; }
     D3D12_GPU_DESCRIPTOR_HANDLE  GetFinalImage();
     SkyBox*                      GetSkyBox() { return _skyBox.get(); };
-    const std::any&              GetRenderPassProperty(std::string_view passName) const;
     SharedResource<RenderTarget> GetSharedRenderTarget() const;
     const bool                   IsDirtyFlag() const { return _isDirtyFlag; }
 

--- a/Source/GA6thFinal_Framework/GraphicsEngine/SSAOWritePass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/SSAOWritePass.cpp
@@ -6,13 +6,11 @@ SSAOWritePass::SSAOWritePass() {}
 
 SSAOWritePass::~SSAOWritePass() {}
 
-void SSAOWritePass::Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique,
-                               ID3D12GraphicsCommandList* commandList)
+void SSAOWritePass::Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique, ID3D12GraphicsCommandList* commandList)
 {
-    __super::Initialize(ownerScene, ownerTechnique, commandList);
+    RenderPass::Initialize(ownerScene, ownerTechnique, commandList);
     auto resolution = Global::device->GetResolution();
-    auto desc       = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8_UNORM, resolution.cx, resolution.cy, 1, 1, 1, 0,
-                                                   D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
+    auto desc       = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8_UNORM, resolution.cx, resolution.cy, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
     
     _renderTarget = MakeSharedResource<RenderTarget>();
     _renderTarget->Initialize(desc, 1.f);
@@ -25,8 +23,7 @@ void SSAOWritePass::AddRenderPassDatas(std::string_view sceneName)
     auto device = Global::device->GetDevice();
     auto desc   = _meshRenderTarget->GetResource()->GetDesc();
     
-    Global::renderPassDatas->AddRenderPassProperty(sceneName, "SSAOWritePass",
-                                                   SSAOPassProperty({0.0005f, 3.f, 2.f, 2.f,0.7f}));
+    Global::renderPassDatas->AddRenderPassProperty("SSAOWritePass", SSAOPassProperty({0.0005f, 3.f, 2.f, 2.f,0.7f}));
     Global::renderPassDatas->AddRenderPassImage(sceneName, "SSAOWritePass", "SSAOTexture", _renderTarget->GetSRVHandle());
 }
 
@@ -41,29 +38,24 @@ void SSAOWritePass::Begin(ID3D12GraphicsCommandList* commandList)
 
 void SSAOWritePass::Draw(ID3D12GraphicsCommandList* commandList)
 {
-    const auto& ssaoProperty =
-        std::any_cast<const SSAOPassProperty&>(_ownerScene->GetRenderPassProperty("SSAOWritePass"));
+    const auto& ssaoProperty      = std::any_cast<const SSAOPassProperty&>(Global::renderPassDatas->GetRenderPassProperty("SSAOWritePass"));
     const auto& renderTargetGroup = Global::multiRenderTargetManager->GetRenderTargetGroup("G-Buffer");
     auto        cameraData        = _ownerScene->_cameraBuffer->GetGPUVirtualAddress();
+
     commandList->SetGraphicsRootSignature(_fxSSAOWrite.GetRootSignature());
     commandList->SetPipelineState(_pipelineState.Get());
     commandList->SetGraphicsRoot32BitConstants(_fxSSAOWrite.GetRootParameterIndex("bit32_5_ssaoProperty"), 5, &ssaoProperty, 0);
     commandList->SetGraphicsRootConstantBufferView(_fxSSAOWrite.GetRootParameterIndex("cameraData"), cameraData);
+
     if (Global::isRayTracing)
     {
-        commandList->SetGraphicsRootDescriptorTable(_fxSSAOWrite.GetRootParameterIndex("normalMap"),
-                                                    renderTargetGroup[DXRGBuffer::DXRNORMAL]->GetSRVHandle());
-
-        commandList->SetGraphicsRootDescriptorTable(_fxSSAOWrite.GetRootParameterIndex("depthMap"),
-                                                    renderTargetGroup[DXRGBuffer::DXRDEPTH]->GetSRVHandle());
+        commandList->SetGraphicsRootDescriptorTable(_fxSSAOWrite.GetRootParameterIndex("normalMap"), renderTargetGroup[DXRGBuffer::DXRNORMAL]->GetSRVHandle());
+        commandList->SetGraphicsRootDescriptorTable(_fxSSAOWrite.GetRootParameterIndex("depthMap"), renderTargetGroup[DXRGBuffer::DXRDEPTH]->GetSRVHandle());
     }
     else
     {
-        commandList->SetGraphicsRootDescriptorTable(_fxSSAOWrite.GetRootParameterIndex("normalMap"),
-                                                    renderTargetGroup[GBuffer::ORM]->GetSRVHandle());
-
-        commandList->SetGraphicsRootDescriptorTable(_fxSSAOWrite.GetRootParameterIndex("depthMap"),
-                                                    renderTargetGroup[GBuffer::DEPTH]->GetSRVHandle());
+        commandList->SetGraphicsRootDescriptorTable(_fxSSAOWrite.GetRootParameterIndex("normalMap"), renderTargetGroup[GBuffer::ORM]->GetSRVHandle());
+        commandList->SetGraphicsRootDescriptorTable(_fxSSAOWrite.GetRootParameterIndex("depthMap"), renderTargetGroup[GBuffer::DEPTH]->GetSRVHandle());
     }
     _ownerScene->_frameQuad->Render(commandList);
 
@@ -72,15 +64,11 @@ void SSAOWritePass::Draw(ID3D12GraphicsCommandList* commandList)
     _sharedRenderTarget->ClearRenderTarget(commandList, 0);
 
     _renderTarget->TransitionResource(commandList, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-    gaussianBlurModule->Execute(commandList, _renderTarget->GetSRVHandle(), _sharedRenderTarget,
-                                _sharedRenderTarget->GetFormat(),
-                               GaussianBlurModule::AXIS_X);
+    gaussianBlurModule->Execute(commandList, _renderTarget->GetSRVHandle(), _sharedRenderTarget, _sharedRenderTarget->GetFormat(), GaussianBlurModule::AXIS_X);
+
     _sharedRenderTarget->TransitionResource(commandList, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-
     _renderTarget->TransitionResource(commandList, D3D12_RESOURCE_STATE_RENDER_TARGET);
-
-    gaussianBlurModule->Execute(commandList, _sharedRenderTarget->GetSRVHandle(), _renderTarget,
-                                _renderTarget->GetFormat(), GaussianBlurModule::BlurType::AXIS_Y);
+    gaussianBlurModule->Execute(commandList, _sharedRenderTarget->GetSRVHandle(), _renderTarget, _renderTarget->GetFormat(), GaussianBlurModule::BlurType::AXIS_Y);
 }
 
 void SSAOWritePass::End(ID3D12GraphicsCommandList* commandList)
@@ -91,14 +79,15 @@ void SSAOWritePass::End(ID3D12GraphicsCommandList* commandList)
 void SSAOWritePass::InitShaderAndPSO()
 {
     PipelineStateStream pss;
-    pss.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-    pss.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-    pss.DepthStencilState            = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-    pss.PrimitiveTopology            = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    pss.BlendState                        = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+    pss.RasterizerState                   = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    pss.DepthStencilState                 = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+    pss.PrimitiveTopology                 = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
     pss.RTVFormats                        = {{_renderTarget->GetFormat()}, 1};
-    pss.DSVFormat                    = _ownerScene->_depthStencilView->GetFormat();
+    pss.DSVFormat                         = _ownerScene->_depthStencilView->GetFormat();
     (&pss.DepthStencilState)->DepthEnable = FALSE;
-    (&pss.RasterizerState)->CullMode = D3D12_CULL_MODE_BACK;
+    (&pss.RasterizerState)->CullMode      = D3D12_CULL_MODE_BACK;
+
     _fxSSAOWrite.SetPipelineStateStream(pss);
-    _pipelineState                   = Global::pipelineStateManager->GetPipelineState(pss);
+    _pipelineState = Global::pipelineStateManager->GetPipelineState(pss);
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/SSRPass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/SSRPass.cpp
@@ -27,7 +27,7 @@ void SSRPass::Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechniqu
 
 void SSRPass::AddRenderPassDatas(std::string_view sceneName) 
 {
-    Global::renderPassDatas->AddRenderPassProperty(sceneName, "SSRPass", SSRPassProperty({0.3f, 0.34f, 200.f,2.f}));
+    Global::renderPassDatas->AddRenderPassProperty("SSRPass", SSRPassProperty({0.3f, 0.34f, 200.f,2.f}));
 }
 
 void SSRPass::Begin(ID3D12GraphicsCommandList* commandList) {}
@@ -44,7 +44,7 @@ void SSRPass::Draw(ID3D12GraphicsCommandList* commandList)
     commandList->RSSetViewports(1, &renderTarget->GetViewport());
     commandList->RSSetScissorRects(1, &renderTarget->GetScissorRect());
 
-    auto        ssrProperty       = std::any_cast<SSRPassProperty>(_ownerScene->GetRenderPassProperty("SSRPass"));
+    auto        ssrProperty       = std::any_cast<SSRPassProperty>(Global::renderPassDatas->GetRenderPassProperty("SSRPass"));
     const auto& renderTargetGroup = Global::multiRenderTargetManager->GetRenderTargetGroup("G-Buffer");
     auto        cameraData        = _ownerScene->_cameraBuffer->GetGPUVirtualAddress();
 

--- a/Source/GA6thFinal_Framework/GraphicsEngine/ShadowMapPass.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/ShadowMapPass.cpp
@@ -8,18 +8,15 @@ ShadowMapPass::~ShadowMapPass() = default;
 
 void ShadowMapPass::Initialize(RenderScene* ownerScene, RenderTechnique* ownerTechnique, ID3D12GraphicsCommandList* commandList)
 {
-    __super::Initialize(ownerScene, ownerTechnique, commandList);
+    RenderPass::Initialize(ownerScene, ownerTechnique, commandList);
 
     CreateShadowMapResource();
-    CreateShaderAndPSO();
-
-    auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(_staticShadowMap.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE);
-    commandList->ResourceBarrier(1, &barrier);
+    CreateShaderAndPSO();  
 }
 
 void ShadowMapPass::AddRenderPassDatas(std::string_view sceneName)
 {
-    auto device = Global::device->GetDevice();   
+    auto device = Global::device->GetDevice();
     
     D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc{};
     for (int i = 0; i < MAX_CASCADES; i++)
@@ -36,7 +33,7 @@ void ShadowMapPass::AddRenderPassDatas(std::string_view sceneName)
         device->CreateShaderResourceView(_shadowMap.Get(), &srvDesc, _debugHandles[i].CPU);
         Global::renderPassDatas->AddRenderPassImage(sceneName, "ShadowMapPass", "ShadowMap", _debugHandles[i].GPU);
 
-        Global::renderPassDatas->AddRenderPassProperty(sceneName, "ShadowMapPass", ShadowPassProperty({0.1f, 200.f, 0.75f}));
+        Global::renderPassDatas->AddRenderPassProperty("ShadowMapPass", ShadowPassProperty({0.01f, 100.f, 0.75f}));
     }
 }
 
@@ -64,31 +61,24 @@ void ShadowMapPass::Update(ID3D12GraphicsCommandList* commandList, const float d
     }
 
     MeshType meshType = END;
-    const auto& shadowMapProps = std::any_cast<ShadowPassProperty>(_ownerScene->GetRenderPassProperty("ShadowMapPass"));
-    if (_isDirtyFlag || !XMVector3Equal(lightDirection, _prevLightDirection) || shadowMapProps != _previousShadowPassProperty)
-    {
-        UpdateCascades(lightDirection);
+    UpdateCascades(lightDirection);
 
-        for (auto& meshInfo : _ownerScene->_activeMeshes[STATIC_MESH])
+    for (int i = 0; i < MESH_TYPE_END; i++)
+    {
+        for (auto& meshInfo : _ownerScene->_activeMeshes[i])
         {
             // cull_back, cull_front, cull_none
-            meshType = MeshType(STATIC_MESH * 3 + (int)meshInfo.Material.CullMode);
+            meshType = MeshType(i * 3 + (int)meshInfo.Material.CullMode);
             _renderDatas[meshType].emplace_back(meshInfo.Mesh, meshInfo.InstanceID, meshInfo.CustomDepth);
         }
-
-        _isDirtyFlag = true;
-    }
-
-    for (auto& meshInfo : _ownerScene->_activeMeshes[SKELETAL_MESH])
-    {
-        // cull_back, cull_front, cull_none
-        meshType = MeshType(SKELETAL_MESH * 3 + (int)meshInfo.Material.CullMode);
-        _renderDatas[meshType].emplace_back(meshInfo.Mesh, meshInfo.InstanceID, meshInfo.CustomDepth);
     }
 }
 
 void ShadowMapPass::Begin(ID3D12GraphicsCommandList* commandList)
 {
+    auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(_shadowMap.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE);
+    commandList->ResourceBarrier(1, &barrier);
+
     commandList->RSSetViewports(1, &_viewport);
     commandList->RSSetScissorRects(1, &_scissorRect);
 }
@@ -100,40 +90,26 @@ void ShadowMapPass::Draw(ID3D12GraphicsCommandList* commandList)
     auto  cascadeData            = _cascadeDataCBV->GetGPUVirtualAddress();
     auto& frameResource          = _ownerScene->_frameResources[currentBackBufferIndex];
 
-    if (_isDirtyFlag)
-    {        
-        for (int i = 0; i < MAX_CASCADES; i++)
-        {
-            commandList->OMSetRenderTargets(0, nullptr, FALSE, &_staticShadowMapDSVs[i]);
-            commandList->ClearDepthStencilView(_staticShadowMapDSVs[i], D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
-
-            // Static
-            commandList->SetGraphicsRootSignature(_fxStaticShadow.GetRootSignature());
-            commandList->SetGraphicsRootDescriptorTable(_fxStaticShadow.GetRootParameterIndex("textures"), resource);
-            commandList->SetGraphicsRootConstantBufferView(_fxStaticShadow.GetRootParameterIndex("cascadeData"), cascadeData);
-            frameResource->SetFrameResource(FrameResourceType::TRANSFORM, _fxStaticShadow.GetRootParameterIndex("matrices"), commandList);
-            frameResource->SetFrameResource(FrameResourceType::MATERIAL, _fxStaticShadow.GetRootParameterIndex("material"), commandList);
-
-            commandList->SetPipelineState(_psos[STATIC_CULL_BACK].Get());
-            DrawMeshes(commandList, STATIC_MESH, STATIC_CULL_BACK, i);
-
-            commandList->SetPipelineState(_psos[STATIC_CULL_FRONT].Get());
-            DrawMeshes(commandList, STATIC_MESH, STATIC_CULL_FRONT, i);
-
-            commandList->SetPipelineState(_psos[STATIC_TWO_SIDED].Get());
-            DrawMeshes(commandList, STATIC_MESH, STATIC_TWO_SIDED, i);
-        }
-
-        _isDirtyFlag = false;
-    }
-
-    // Copy previous cascade data
-    CopyPreviousCascadeData(commandList);
-
     for (int i = 0; i < MAX_CASCADES; i++)
     {
         commandList->OMSetRenderTargets(0, nullptr, FALSE, &_shadowMapDSVs[i]);
-        //commandList->ClearDepthStencilView(_shadowMapDSVs[i], D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+        commandList->ClearDepthStencilView(_shadowMapDSVs[i], D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+
+        // Static
+        commandList->SetGraphicsRootSignature(_fxStaticShadow.GetRootSignature());
+        commandList->SetGraphicsRootDescriptorTable(_fxStaticShadow.GetRootParameterIndex("textures"), resource);
+        commandList->SetGraphicsRootConstantBufferView(_fxStaticShadow.GetRootParameterIndex("cascadeData"), cascadeData);
+        frameResource->SetFrameResource(FrameResourceType::TRANSFORM, _fxStaticShadow.GetRootParameterIndex("matrices"), commandList);
+        frameResource->SetFrameResource(FrameResourceType::MATERIAL, _fxStaticShadow.GetRootParameterIndex("material"), commandList);
+
+        commandList->SetPipelineState(_psos[STATIC_CULL_BACK].Get());
+        DrawMeshes(commandList, STATIC_MESH, STATIC_CULL_BACK, i);
+
+        commandList->SetPipelineState(_psos[STATIC_CULL_FRONT].Get());
+        DrawMeshes(commandList, STATIC_MESH, STATIC_CULL_FRONT, i);
+
+        commandList->SetPipelineState(_psos[STATIC_TWO_SIDED].Get());
+        DrawMeshes(commandList, STATIC_MESH, STATIC_TWO_SIDED, i);
 
         // Skeletal
         commandList->SetGraphicsRootSignature(_fxSkeletalShadow.GetRootSignature());
@@ -158,11 +134,6 @@ void ShadowMapPass::End(ID3D12GraphicsCommandList* commandList)
 {
     auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(_shadowMap.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
     commandList->ResourceBarrier(1, &barrier);
-
-    if (_ownerScene->IsDirtyFlag())
-    {
-        _isDirtyFlag = true;
-    }
 }
 
 void ShadowMapPass::CreateShadowMapResource()
@@ -170,10 +141,9 @@ void ShadowMapPass::CreateShadowMapResource()
     _cascadeDataCBV = std::make_unique<ConstantBufferView>();
     _cascadeDataCBV->Initialize(sizeof(CascadeData));
 
-    for (int i = 0; i < MAX_CASCADES; i++)
+    for (auto & shadowMapDSV : _shadowMapDSVs)
     {
-        Global::viewManager->AddDescriptorHeap(ViewManager::Type::DEPTH_STENCIL, _shadowMapDSVs[i]);
-        Global::viewManager->AddDescriptorHeap(ViewManager::Type::DEPTH_STENCIL, _staticShadowMapDSVs[i]);
+        Global::viewManager->AddDescriptorHeap(ViewManager::Type::DEPTH_STENCIL, shadowMapDSV);
     }
 
     Global::viewManager->AddDescriptorHeap(ViewManager::Type::SHADER_RESOURCE, _shadowMapSRV);
@@ -190,11 +160,6 @@ void ShadowMapPass::CreateShadowMapResource()
                                                              IID_PPV_ARGS(&_shadowMap));
     FAILED_CHECK_MESSAGE(hr, L"ShadowMapPass::CreateShadowMapResource device->CreateCommittedResource Failed");
 
-    hr = device->CreateCommittedResource(&heapProperties, D3D12_HEAP_FLAG_NONE, &desc,
-                                         D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &optClear,
-                                         IID_PPV_ARGS(&_staticShadowMap));
-    FAILED_CHECK_MESSAGE(hr, L"ShadowMapPass::CreateShadowMapResource device->CreateCommittedResource Failed");
-
     // Create DSV for Shadow Map
     D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc{};
     dsvDesc.Format        = DXGI_FORMAT_D32_FLOAT;
@@ -205,7 +170,6 @@ void ShadowMapPass::CreateShadowMapResource()
         dsvDesc.Texture2DArray.FirstArraySlice = i;
         dsvDesc.Texture2DArray.ArraySize       = 1;
         device->CreateDepthStencilView(_shadowMap.Get(), &dsvDesc, _shadowMapDSVs[i]);
-        device->CreateDepthStencilView(_staticShadowMap.Get(), &dsvDesc, _staticShadowMapDSVs[i]);
     }
 
     // Create SRV for Shadow Map
@@ -240,8 +204,8 @@ void ShadowMapPass::CreateShaderAndPSO()
     pss.BlendState                               = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
     pss.DepthStencilState                        = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
     pss.RasterizerState                          = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-    (&pss.RasterizerState)->DepthBias            = 100;
-    (&pss.RasterizerState)->DepthBiasClamp       = 0.0f;
+    (&pss.RasterizerState)->DepthBias            = 5000;
+    (&pss.RasterizerState)->DepthBiasClamp       = 0.01f;
     (&pss.RasterizerState)->SlopeScaledDepthBias = 1.5f;
     pss.PrimitiveTopology                        = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
     pss.DSVFormat                                = DXGI_FORMAT_D32_FLOAT;
@@ -276,14 +240,23 @@ void ShadowMapPass::UpdateCascades(const Vector3& lightDirection)
 
     XMVECTOR lightDir = lightDirection;
 
-    auto& camera = _ownerScene->_camera;
+    auto& camera = _ownerScene->_camera;    
 
-    const auto& shadowMapProps = std::any_cast<ShadowPassProperty>(_ownerScene->GetRenderPassProperty("ShadowMapPass"));
+    const auto& shadowMapProps = std::any_cast<const ShadowPassProperty&>(Global::renderPassDatas->GetRenderPassProperty("ShadowMapPass"));
 
     // 1. 캐스케이드 분할 거리 계산
     float nearZ  = std::max(0.01f, shadowMapProps.NearPlane);
     float farZ   = std::max(nearZ + 1, shadowMapProps.FarPlane);
     float lambda = shadowMapProps.SplitFactor;
+
+    XMVECTOR L   = XMVector3Normalize(lightDir);
+    XMVECTOR upY = XMVectorSet(0, 1, 0, 0);
+    XMVECTOR upZ = XMVectorSet(0, 0, 1, 0);
+    float    d   = fabsf(XMVectorGetX(XMVector3Dot(L, upY)));
+    
+    XMVECTOR U = (d > 0.95f) ? upZ : upY;
+    XMVECTOR R = XMVector3Normalize(XMVector3Cross(U, L));
+    U          = XMVector3Cross(L, R);
 
     for (int i = 0; i < MAX_CASCADES; i++)
     {
@@ -291,60 +264,65 @@ void ShadowMapPass::UpdateCascades(const Vector3& lightDirection)
         float split_log     = nearZ * std::powf(farZ / nearZ, ratio);
         float split_uniform = nearZ + (farZ - nearZ) * ratio;
 
-        _cascadeData.CascadeSplits[i] = lambda * split_log + (1.0f - lambda) * split_uniform;
+        _cascadeData.CascadeSplits[i] = lambda * split_log + (1.0f - lambda) * split_uniform;        
     }
 
-    for (uint32_t c = 0; c < MAX_CASCADES; ++c)
+    for (int i = 0; i < MAX_CASCADES; i++)
     {
-        // 1. 해당 스플릿 z 범위로 카메라 뷰 절두체 8 코너 산출
-        BoundingFrustum worldFrustum = camera->GetFrustum();
-        worldFrustum.Near            = c == 0 ? nearZ : _cascadeData.CascadeSplits[c - 1];
-        worldFrustum.Far             = _cascadeData.CascadeSplits[c];
-        
-        // 2. 절두체 코너들을 월드 좌표로 변환 → AABB 구함
+        float prevSplit = i == 0 ? nearZ : _cascadeData.CascadeSplits[i - 1];
+        float splitFar  = _cascadeData.CascadeSplits[i];
+
+        // 1. 해당 캐스케이드의 프러스텀 조각을 정의
+        BoundingFrustum frustumInProjSpace(camera->GetProjectionMatrix());
+        frustumInProjSpace.Near = prevSplit;
+        frustumInProjSpace.Far  = splitFar;
+
+        // 2. 월드 공간으로 변환
+        BoundingFrustum frustumInWorldSpace;
+        frustumInProjSpace.Transform(frustumInWorldSpace, camera->GetWorldMatrix());
+
+        // 3. 월드 공간 프러스텀의 8개 코너를 구함
         XMFLOAT3 corners[8];
-        worldFrustum.GetCorners(corners);
+        frustumInWorldSpace.GetCorners(corners);
+
+        // 4. 8개 코너를 포함하는 바운딩 스피어의 중심과 반지름을 계산
         XMVECTOR frustumCenter = XMVectorZero();
-
-        for (auto& corner : corners)
+        for (const auto& corner : corners)
         {
-            frustumCenter += XMLoadFloat3(&corner);
+            frustumCenter = XMVectorAdd(frustumCenter, XMLoadFloat3(&corner));
         }
-        frustumCenter /= 8.0f;
+        frustumCenter = XMVectorScale(frustumCenter, 1.0f / 8.0f);
 
-        float radius = 0.f;
-        for (auto& corner : corners)
+        float frustumRadius = 0.0f;
+        for (const auto& corner : corners)
         {
-            radius = std::max(radius, XMVectorGetX(XMVector3Length(XMLoadFloat3(&corner) - frustumCenter)));
+            float distance = XMVectorGetX(XMVector3Length(XMVectorSubtract(XMLoadFloat3(&corner), frustumCenter)));
+            frustumRadius = std::max(frustumRadius, distance);
         }
-        // 텍셀 스냅을 위해 울림
-        radius = std::ceil(radius * 16.0f) / 16.0f;
 
-        // 3. 라이트 뷰
-        XMVECTOR eye    = frustumCenter - lightDir * (radius + shadowMapProps.Offset1);
-        XMVECTOR target = frustumCenter;
-        XMVECTOR up     = XMVectorSet(0, 1, 0, 0);
+        // 5. 라이트 뷰 행렬 생성
+        // 스피어 중심을 바라보되, 반지름만큼 뒤로 물러나서 모든 것을 볼 수 있도록 eye 위치 설정
+        XMVECTOR eyePosition = XMVectorSubtract(frustumCenter, XMVectorScale(L, frustumRadius));
+        XMMATRIX lightView = XMMatrixLookAtLH(eyePosition, frustumCenter, U);
 
-        if (std::fabs(XMVectorGetX(XMVector3Dot(up, lightDir))) > 0.99f)
-            up = XMVectorSet(1, 0, 0, 0);
+        // 6. 안정적인 라이트 직교 투영 행렬 생성
+        // 스피어의 지름(radius * 2)을 투영의 너비와 높이로 사용
+        float viewWidth = frustumRadius * 2.0f;
+        float viewHeight = frustumRadius * 2.0f;
+        // Z 범위는 스피어를 충분히 포함하도록 설정 (0 부터 지름까지)
+        XMMATRIX lightProj = XMMatrixOrthographicLH(viewWidth, viewHeight, 0.0f, frustumRadius * 2.0f);
 
-        XMMATRIX lightView = XMMatrixLookAtLH(eye, target, up);
-
-        // 4. 라이트 공간 Orthographic Projection
-        XMMATRIX lightProj = XMMatrixOrthographicLH(radius * 2, radius * 2, 0.0f, radius * 2 + shadowMapProps.Offset2);
-        XMStoreFloat4x4(&_cascadeData.ShadowVP[c], XMMatrixTranspose(lightView * lightProj));
-    }
+        // 7. 최종 행렬 계산 및 저장
+        _cascadeData.ShadowVP[i] = XMMatrixTranspose(lightView * lightProj);
+    }    
 
     // 계산된 모든 캐스케이드 데이터를 상수 버퍼에 한 번에 업데이트
     _cascadeDataCBV->UpdateBuffer(&_cascadeData);
-
-    _prevLightDirection         = lightDirection;
-    _previousShadowPassProperty = shadowMapProps;
 }
 
 void ShadowMapPass::DrawMeshes(ID3D12GraphicsCommandList* commandList, int shaderType, MeshType meshType, int cascadedIndex)
 {
-    const auto& parallaxMappingProperty = std::any_cast<const ParallaxMappingProperty&>(_ownerScene->GetRenderPassProperty("G-BufferPass"));
+    const auto& parallaxMappingProperty = std::any_cast<const ParallaxMappingProperty&>(Global::renderPassDatas->GetRenderPassProperty("G-BufferPass"));
 
     switch (shaderType)
     {
@@ -377,19 +355,4 @@ void ShadowMapPass::DrawMeshes(ID3D12GraphicsCommandList* commandList, int shade
 
         mesh->Render(commandList);
     }
-}
-
-void ShadowMapPass::CopyPreviousCascadeData(ID3D12GraphicsCommandList* commandList)
-{
-    D3D12_RESOURCE_BARRIER barriers[2];
-    barriers[0] = CD3DX12_RESOURCE_BARRIER::Transition(_staticShadowMap.Get(), D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_COPY_SOURCE);
-    barriers[1] = CD3DX12_RESOURCE_BARRIER::Transition(_shadowMap.Get(), D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_COPY_DEST);
-
-    commandList->ResourceBarrier(2, barriers);
-    commandList->CopyResource(_shadowMap.Get(), _staticShadowMap.Get());
-
-    barriers[0] = CD3DX12_RESOURCE_BARRIER::Transition(_staticShadowMap.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_WRITE);
-    barriers[1] = CD3DX12_RESOURCE_BARRIER::Transition(_shadowMap.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_DEPTH_WRITE);
-
-    commandList->ResourceBarrier(2, barriers);
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/ShadowMapPass.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/ShadowMapPass.h
@@ -44,16 +44,12 @@ private:
     // 매 프레임 실행되는 핵심 로직
     void UpdateCascades(const Vector3& lightDirection);
     void DrawMeshes(ID3D12GraphicsCommandList* commandList, int shaderType, MeshType meshType, int cascadedIndex);
-    void CopyPreviousCascadeData(ID3D12GraphicsCommandList* commandList);
 
 private:
     FX<GE::VS::STATIC_SHADOW_FR, GE::PS::SHADOW>   _fxStaticShadow;
     FX<GE::VS::SKELETAL_SHADOW_FR, GE::PS::SHADOW> _fxSkeletalShadow;
 
     // 그림자 맵 리소스
-    ComPtr<ID3D12Resource>                   _staticShadowMap;
-    D3D12_CPU_DESCRIPTOR_HANDLE              _staticShadowMapDSVs[MAX_CASCADES];
-    DescriptorHandles                        _staticShadowMapSRV;
     ComPtr<ID3D12Resource>                   _shadowMap;
     D3D12_CPU_DESCRIPTOR_HANDLE              _shadowMapDSVs[MAX_CASCADES];
     DescriptorHandles                        _shadowMapSRV;
@@ -69,9 +65,4 @@ private:
 
     // 디버그용
     DescriptorHandles _debugHandles[MAX_CASCADES];
-
-    // 테스트
-    ShadowPassProperty _previousShadowPassProperty;
-    Vector3            _prevLightDirection = Vector3::Zero;
-    bool               _isDirtyFlag        = false;
 };

--- a/Source/GA6thFinal_Framework/GraphicsEngine/SkyBox.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/SkyBox.cpp
@@ -166,7 +166,7 @@ void SkyBox::SetIBLTexture(std::wstring_view path)
 
 void SkyBox::Initialize()
 {
-    _box->InitializeInverted(1000.f, 1000.f, 1000.f, 0);
+    _box->InitializeInverted(500.f, 500.f, 500.f, 0);
     HRESULT hr = S_OK;
 
     FAILED_CHECK_MESSAGE(hr, L"SkyBox::Initialize device->CreateDescriptorHeap Failed");

--- a/Source/GA6thFinal_Framework/GraphicsEngine/VolumetricFogTechnique.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/VolumetricFogTechnique.cpp
@@ -5,9 +5,9 @@
 #include "FogCompositePass.h"
 #include "RenderPass.h"
 
-VolumetricFogTechnique::VolumetricFogTechnique(){}
+VolumetricFogTechnique::VolumetricFogTechnique() = default;
 
-VolumetricFogTechnique::~VolumetricFogTechnique() {}
+VolumetricFogTechnique::~VolumetricFogTechnique() = default;
 
 void VolumetricFogTechnique::Initialize(ID3D12GraphicsCommandList* commandList)
 {
@@ -37,9 +37,11 @@ void VolumetricFogTechnique::Initialize(ID3D12GraphicsCommandList* commandList)
     pass = std::make_unique<FogLightInjectionPass>();
     pass->Initialize(_ownerScene, this, commandList);
     AddRenderPass(std::move(pass));
+
     pass = std::make_unique<FogLightAccmulatePass>();
     pass->Initialize(_ownerScene, this, commandList);
     AddRenderPass(std::move(pass));
+
     pass = std::make_unique<FogCompositePass>();
     pass->Initialize(_ownerScene, this, commandList);
     AddRenderPass(std::move(pass));
@@ -56,12 +58,13 @@ void VolumetricFogTechnique::Execute(ID3D12GraphicsCommandList* commandList)
 
 void VolumetricFogTechnique::UpdateConstantBuffer()
 {
-    const auto& volumetricFogProperty =
-        std::any_cast<const VolumetricFogProperty&>(_ownerScene->GetRenderPassProperty("VolumetricFogData"));
+    const auto& volumetricFogProperty = std::any_cast<const VolumetricFogProperty&>(Global::renderPassDatas->GetRenderPassProperty("VolumetricFogData"));
+
     XMMATRIX view = _ownerScene->_camera->GetViewMatrix();
     XMMATRIX proj = _ownerScene->_camera->GetProjectionMatrix();
     XMMATRIX viewProj = XMMatrixMultiply(view, proj);
     XMMATRIX invViewProj = XMMatrixInverse(nullptr, viewProj);
+
     // 상수 버퍼 관련 update
     VolumetricFogData fogData;
     fogData.FogAnisotropy                    = volumetricFogProperty.FogAnisotropy;

--- a/Source/GA6thFinal_Framework/GraphicsEngine/VolumetricFogTechnique.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/VolumetricFogTechnique.h
@@ -7,7 +7,9 @@ class VolumetricFogTechnique : public RenderTechnique
 public:
     VolumetricFogTechnique();
     virtual ~VolumetricFogTechnique();
-    ConstantBufferView*  GetConstantBufferView() { return _constantBuffer.get(); }
+
+public:
+    ConstantBufferView* GetConstantBufferView() { return _constantBuffer.get(); }
     ConstantBufferView* GetVolumetricFogBufferView() { return _volumetricFogBuffer.get(); }
 
 public:

--- a/Source/GA6thFinal_Framework/Shaders/CommonStructs.hlsli
+++ b/Source/GA6thFinal_Framework/Shaders/CommonStructs.hlsli
@@ -5,7 +5,7 @@
 #define MAX_POINT_LIGHT 32
 #define MAX_SPOT_LIGHT 16
 
-#define MAX_CASCADES 4
+#define MAX_CASCADES 3
 
 struct MatrixData
 {
@@ -98,7 +98,7 @@ struct PostProcessData
 struct CascadeData
 {
     matrix ShadowVP[MAX_CASCADES];
-    float CascadeSplits[MAX_CASCADES];
+    float3 CascadeSplits; // x=split1, y=split2, z=split3
 };
 
 struct GbufferData


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-418/custom_shader_pass

---

## 🛠️ 변경 사항
- `EditorRenderPassData.cpp`: `ImGui::Table`을 활용한 UI 개선 및 `CenterText` 함수 추가.
- `RenderPassDatas`: `sceneName` 계층 제거로 데이터 구조 단순화.
- `MAX_CASCADES` 값을 4에서 3으로 변경(`Enums.h`, `CommonStructs.hlsli` 등).
- 불필요한 함수 제거 및 소멸자 단순화(`FogCompositePass`, `FogLightAccmulatePass` 등).
- `ShadowMapPass`: 캐스케이드 계산 로직 개선 및 관련 필드 제거.
- SkyBox 크기 조정(1000.f → 500.f).
- 전반적으로 `Global::renderPassDatas`를 활용하도록 코드 리팩토링.
- `CSM`이 정상작동 하지 않던 버그 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?
