### PR TITLE
[FEATURE/VG-419] 텍스처 아틀라스 기능 추가 및 렌더링 로직 수정

### DIFF
--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/UI/Elements/Image/ImageElement.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/UI/Elements/Image/ImageElement.h
@@ -14,7 +14,7 @@ public:
     ~ImageElement() override;
 
 public:
-    REFLECT_PROPERTY(FilePath, Alpha)
+    REFLECT_PROPERTY(FilePath, Alpha, Culumn, Row, CulumnIndex, RowIndex)
 
     GETTER_ONLY(std::string, FilePath) { return _guidRef.ToPath().string(); }
     PROPERTY(FilePath)
@@ -27,6 +27,38 @@ public:
         UpdateRendererAlpha(clampedAlpha);
     }
     PROPERTY(Alpha)
+    
+    GETTER(int, Culumn) { return ReflectFields->Culumn; }
+    SETTER(int, Culumn)
+    {
+        ReflectFields->Culumn = std::min(0, ReflectFields->Culumn);
+        if (_renderer) _renderer->SetAtlas(ReflectFields->Culumn, ReflectFields->Row);
+    }
+    PROPERTY(Culumn)
+
+    GETTER(int, Row) { return ReflectFields->Row; }
+    SETTER(int, Row)
+    {
+        ReflectFields->Row = std::min(0, ReflectFields->Row);
+        if (_renderer) _renderer->SetAtlas(ReflectFields->Culumn, ReflectFields->Row);
+    }
+    PROPERTY(Row)
+
+    GETTER(int, CulumnIndex) { return ReflectFields->CulumnIndex; }
+    SETTER(int, CulumnIndex)
+    {
+        ReflectFields->CulumnIndex = std::clamp(value, 0, ReflectFields->Culumn);
+        if (_renderer) _renderer->SetAtlasIndex(ReflectFields->CulumnIndex, ReflectFields->RowIndex);
+    }
+    PROPERTY(CulumnIndex)
+
+    GETTER(int, RowIndex) { return ReflectFields->RowIndex; }
+    SETTER(int, RowIndex)
+    {
+        ReflectFields->RowIndex = std::clamp(value, 0, ReflectFields->Row);
+        if (_renderer) _renderer->SetAtlasIndex(ReflectFields->CulumnIndex, ReflectFields->RowIndex);
+    }
+    PROPERTY(RowIndex)
 
 public:
     /// <summary>
@@ -68,6 +100,10 @@ protected:
     REFLECT_FIELDS_BEGIN(DrawUIComponent)
     std::string Guid;
     float       Alpha = 1.0f;
+    int         Culumn = 1;
+    int         Row    = 1;
+    int         CulumnIndex = 0;
+    int         RowIndex    = 0;
     REFLECT_FIELDS_END(ImageElement)
 
 private:

--- a/Source/GA6thFinal_Framework/GraphicsEngine/RenderScene.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/RenderScene.cpp
@@ -405,39 +405,44 @@ void RenderScene::UpdateUI()
         if (nullptr == texture)
             continue;
 
-        auto     size = component->GetSize();
-        XMMATRIX world = component->GetWorldMatrix();
-        XMMATRIX scale = XMMatrixIdentity();
+        auto     size        = component->GetSize();
+        XMMATRIX world       = component->GetWorldMatrix();
+        XMMATRIX scale       = XMMatrixIdentity();
         XMMATRIX translation = XMMatrixIdentity();
 
         switch (component->GetType())
         {
-        case SpriteType::MODE_2D:
-            scale = XMMatrixScaling((float)size.cx, (float)-size.cy, 1.f);
-            translation = XMMatrixTranslation(size.cx * 0.5f, size.cy * 0.5f, 0.f);
-            break;
-        case SpriteType::MODE_3D:
-        {
-            XMVECTOR s, r, t;
-            XMMatrixDecompose(&s, &r, &t, world);
+            case SpriteType::MODE_2D:
+                scale = XMMatrixScaling((float)size.cx, (float)-size.cy, 1.f);
+                translation = XMMatrixTranslation(size.cx * 0.5f, size.cy * 0.5f, 0.f);
+                break;
+            case SpriteType::MODE_3D:
+            {
+                XMVECTOR s, r, t;
+                XMMatrixDecompose(&s, &r, &t, world);
 
-            XMVECTOR combine = XMQuaternionMultiply(r, _camera->GetRotation());
-            world = XMMatrixScalingFromVector(s) * XMMatrixRotationQuaternion(combine) * XMMatrixTranslationFromVector(t);
-            [[fallthrough]];
-        }
-        case SpriteType::MODE_25D:
-        {
-            float ratio = (float)size.cx / (float)size.cy;
-            scale       = XMMatrixScaling(ratio, 1.f, 1.f);
-            break;
-        }
+                XMVECTOR combine = XMQuaternionMultiply(r, _camera->GetRotation());
+                world = XMMatrixScalingFromVector(s) * XMMatrixRotationQuaternion(combine) * XMMatrixTranslationFromVector(t);
+                [[fallthrough]];
+            }
+            case SpriteType::MODE_25D:
+            {
+                float ratio = (float)size.cx / (float)size.cy;
+                scale       = XMMatrixScaling(ratio, 1.f, 1.f);
+                break;
+            }
         }
         
         world = XMMatrixTranspose(scale * world * translation);
         _uiMatrices.push_back(world);
 
-        UIMaterial material{.ID = texture->GetID(), .Alpha = component->GetAlpha()};
-        _uiMaterials.push_back(material);
+        UIMaterial uiMaterial{.ID          = texture->GetID(),
+                              .Alpha       = component->GetAlpha(),
+                              .NumCulmn    = component->GetNumCulumn(),
+                              .NumRow      = component->GetNumRow(),
+                              .CulumnIndex = component->GetCulumnIndex(),
+                              .RowIndex    = component->GetRowIndex()};
+        _uiMaterials.push_back(uiMaterial);
     }
 }
 

--- a/Source/GA6thFinal_Framework/GraphicsEngine/SpriteRenderer.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/SpriteRenderer.cpp
@@ -6,10 +6,15 @@ SpriteRenderer::SpriteRenderer(const Matrix& world, SpriteType type)
     , _type(type)
     , _size()
     , _materialData()
+    , _alpha(1.f)
+    , _numCulumn(1)
+    , _numRow(1)
+    , _culumnIndex(0)
+    , _rowIndex(0)
 {
 }
 
-SpriteRenderer::~SpriteRenderer() {}
+SpriteRenderer::~SpriteRenderer() = default;
 
 void SpriteRenderer::SetTexture(std::shared_ptr<Texture> texture)
 {
@@ -17,7 +22,8 @@ void SpriteRenderer::SetTexture(std::shared_ptr<Texture> texture)
 
     if (_texture)
     {
-        _size = _texture->GetSize();
+        _size   = _texture->GetSize();
+        _origin = _size;
     }
 }
 
@@ -30,4 +36,16 @@ void SpriteRenderer::SetLinearFill(float fill)
 void SpriteRenderer::SetAlpha(const float alpha)
 {
     _alpha = std::clamp(alpha, 0.f, 1.f);
+}
+
+void SpriteRenderer::SetAtlas(UINT culumn, UINT row)
+{
+    _numCulumn = std::max(culumn, 1u);
+    _numRow    = std::max(row, 1u);
+}
+
+void SpriteRenderer::SetAtlasIndex(UINT culumnIndex, UINT rowIndex)
+{
+    _culumnIndex = std::min(culumnIndex, _numCulumn - 1);
+    _rowIndex    = std::min(rowIndex, _numRow - 1);
 }

--- a/Source/GA6thFinal_Framework/GraphicsEngine/SpriteRenderer.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/SpriteRenderer.h
@@ -12,20 +12,33 @@ public:
     const SpriteType      GetType() const { return _type; }
     const Texture*        GetTexture() const { return _texture.get(); }
     const SIZE&           GetSize() const { return _size; }
-    const UIMaterialData& GetMaterialData() const { return _materialData; }
+    const SIZE&           GetOriginSize() const { return _origin; }    
     const float           GetAlpha() const { return _alpha; }
+    const UIMaterialData& GetMaterialData() const { return _materialData; }
+    const UINT            GetNumCulumn() const { return _numCulumn; }
+    const UINT            GetNumRow() const { return _numRow; }
+    const UINT            GetCulumnIndex() const { return _culumnIndex; }
+    const UINT            GetRowIndex() const { return _rowIndex; }
 
+public:
     void SetType(SpriteType type) { _type = type; }
     void SetSize(SIZE size) { _size = size; }
     void SetTexture(std::shared_ptr<Texture> texture);
     void SetLinearFill(float fill);
     void SetAlpha(float alpha);
+    void SetAtlas(UINT culumn, UINT row);
+    void SetAtlasIndex(UINT culumnIndex, UINT rowIndex);
 
 private:
     std::shared_ptr<Texture> _texture;
     const Matrix&            _worldMatrix;
-    SpriteType               _type;
     SIZE                     _size;
+    SIZE                     _origin;
     UIMaterialData           _materialData;
+    SpriteType               _type;
+    UINT                     _numCulumn;
+    UINT                     _numRow;
+    UINT                     _culumnIndex;
+    UINT                     _rowIndex;
     float                    _alpha;
 };

--- a/Source/GA6thFinal_Framework/GraphicsEngine/Structs.h
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/Structs.h
@@ -25,6 +25,16 @@ struct ObjectData
     FLOAT Alpha;
 };
 
+struct UIMaterial
+{
+    UINT  ID;
+    float Alpha;
+    UINT  NumCulmn;
+    UINT  NumRow;
+    UINT  CulumnIndex;
+    UINT  RowIndex;
+};
+
 struct ShadowObjectData : public ObjectData
 {
     UINT CascadedIndex;
@@ -96,12 +106,6 @@ struct PostProcessData
     Vector2      TexelSize;
     unsigned int PostProcessMask;
     unsigned int MipLevel;
-};
-
-struct UIMaterial
-{
-    UINT  ID;
-    float Alpha;
 };
 
 struct PipelineStateStream

--- a/Source/GA6thFinal_Framework/Shaders/ps_ui.hlsl
+++ b/Source/GA6thFinal_Framework/Shaders/ps_ui.hlsl
@@ -9,14 +9,15 @@ struct PSInput
 
 struct Material
 {
-    uint textureID;
-    float Alpha;
+    uint ID;
+    float alpha;
+    uint4 atlas;
 };
 
 struct UIMaterialData
 {
-    uint Type;
-    float Fill;
+    uint type;
+    float fill;
 };
 
 StructuredBuffer<Material> material;
@@ -32,13 +33,19 @@ float4 ps_main(PSInput input) : SV_Target
 {
     uint index = IDs[input.instanceID];
     
-    float4 color = textures[material[index].textureID].Sample(samLinear_wrap, input.uv);
-    color.a *= material[index].Alpha;
+    float2 culmn_row = (float2) material[index].atlas.xy;
+    float2 current = (float2) material[index].atlas.zw;
+    
+    float2 offset = 1 / culmn_row;
+    float2 uv = input.uv / culmn_row;
+
+    float4 color = textures[material[index].ID].Sample(samLinear_wrap, offset * current + uv);
+    color.a *= material[index].alpha;
         
-    switch (uiMaterialData[index].Type)
+    switch (uiMaterialData[index].type)
     {
         case LINEAR_FILL:
-            clip(uiMaterialData[index].Fill - input.uv.x);
+            clip(uiMaterialData[index].fill - input.uv.x);
             break;
     }
 


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-419/atlas_renderer

---

## 🛠️ 변경 사항
- `ImageElement.h`: `Culumn`, `Row`, `CulumnIndex`, `RowIndex` 필드 추가 및 관련 `GETTER/SETTER` 구현.
- `SpriteRenderer`: 텍스처 아틀라스 설정 및 인덱스 관리 함수(`SetAtlas`, `SetAtlasIndex`) 추가.
- `RenderScene.cpp`: `UIMaterial` 구조체 확장 및 UI 렌더링 로직 수정.
- `Structs.h`: `UIMaterial` 구조체에 텍스처 아틀라스 필드 추가.
- `ps_ui.hlsl`: 텍스처 샘플링 로직 수정 및 `Material` 구조체 확장.

---

## ✅ 체크리스트
- [ ] 코드에 불필요한 로그는 제거했나요?
- [ ] 코드에 불필요한 주석은 제거했나요?
- [ ] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [ ] 코드 스타일 가이드를 따랐나요?
