### PR TITLE
[FEATURE/VG-373] QTE 가이드 버튼 출력 및 각종 버그 픽스

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GameCore/Component/UIRoot.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/GameCore/Component/UIRoot.cpp
@@ -326,16 +326,25 @@ void UIRoot::CheckNavigationIdFlawless(const UIBaseComponent* newComponent)
         Transform& transform = newComponent->transform;
         UpdateNavigationMap(transform);
 
+        NavigationID maxID = INVALID_NAVIGATION_ID;
+
         std::vector<UINavigationComponent*> uiNavigationComponents;
 
-        Transform::ForeachBFS(transform, [this, &uiNavigationComponents](const Transform* dfsTransform) {
+        Transform::ForeachBFS(transform, [this, &uiNavigationComponents, &maxID](const Transform* dfsTransform) {
             const GameObject& gameObject = dfsTransform->gameObject;
             if (UINavigationComponent* navigationComponent = gameObject.GetComponentDynamic<UINavigationComponent>();
                 nullptr != navigationComponent)
             {
                 uiNavigationComponents.push_back(navigationComponent);
+                NavigationID id = navigationComponent->ID;
+                maxID           = std::max(maxID, id);
             }
         });
+
+        if (ReflectFields->LastID <= maxID)
+        {
+            ReflectFields->LastID = maxID + 1;
+        }
 
         std::ranges::for_each(uiNavigationComponents, [this, &uiNavigationComponents](
                                                           UINavigationComponent* navigationComponent) {

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Camera/CameraComponent.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Camera/CameraComponent.cpp
@@ -33,7 +33,7 @@ Vector3 CameraComponent::WorldToNDC(const Vector3& worldPos)
 
 Vector3 CameraComponent::WorldToNDC(const Vector3& worldPos, const Matrix& viewMatrix, const Matrix& projMatrix)
 {
-    Matrix vp = projMatrix * viewMatrix;
+    Matrix vp = viewMatrix * projMatrix;
 
     // 월드좌표 >> 클립공간
     Vector4 wolrd   = Vector4(worldPos.x, worldPos.y, worldPos.z, 1.0f);

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Camera/CameraComponent.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Camera/CameraComponent.cpp
@@ -76,9 +76,9 @@ Vector3 CameraComponent::ViewportToWorld(const Vector3& screenPos)
 {
     if (_camera)
     {
-        const float camNear             = _camera->GetNearZ();
-        const float camFar              = _camera->GetFarZ();
-        const SIZE& resolution          = UmGraphics.GetResolution();
+        const float camNear     = _camera->GetNearZ();
+        const float camFar      = _camera->GetFarZ();
+        const SIZE& resolution  = UmGraphics.GetResolution();
         if (resolution.cx <= 0 || resolution.cy <= 0)
         {
             return Vector3::Zero;

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/ItemDropSystem/ItemDropSystem.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/ItemDropSystem/ItemDropSystem.cpp
@@ -299,6 +299,15 @@ void ItemDropSystem::PlayItemDropUISequence()
         StageClearCount = StageClearCount + 1;
     }
 
+    if (auto restartButton = GameObject::FindWithTag("Restart Button").lock())
+    {
+        UINavigationComponent* nav = restartButton->GetComponentDynamic<UINavigationComponent>();
+        if (nullptr != nav)
+        {
+            nav->Focus();
+        }
+    }
+
     if (auto turnQueue = GameObject::FindWithTag("Turn Queue Panel").lock())
     {
         turnQueue->ActiveSelf = false;

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/ItemDropSystem/UINavi/ReturnToMapNavi.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/ItemDropSystem/UINavi/ReturnToMapNavi.cpp
@@ -12,7 +12,7 @@ ReturnToMapNavi::ReturnToMapNavi()
             {
 
                 const DragDropAsset::Data* data = static_cast<DragDropAsset::Data*>(payLoad->Data);
-                if (const auto extension = data->GetPath().extension(); extension == L".png" || extension == L".jpeg")
+                if (const auto extension = data->GetPath().extension(); extension == L".UmScene")
                 {
                     _guidRef                = data->GetGuid();
                     ReflectFields->MapScene = _guidRef.string();

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/MainMenu/NewGame.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/MainMenu/NewGame.cpp
@@ -25,5 +25,6 @@ NewGame::~NewGame() = default;
 
 void NewGame::Submit()
 {
-    UmSceneManager.LoadScene(ReflectFields->NextSceneGuid);
+    File::Path path = File::Guid(ReflectFields->NextSceneGuid).ToPath();
+    UmSceneManager.LoadScene(path.string());
 }

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/MainMenu/NewGame.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/MainMenu/NewGame.cpp
@@ -13,7 +13,7 @@ NewGame::NewGame()
                 const DragDropAsset::Data* data = static_cast<DragDropAsset::Data*>(payLoad->Data);
                 if (const auto extension = data->GetPath().extension(); extension == L".UmScene")
                 {
-                    ReflectFields->NextScene = data->GetPath().string();
+                    ReflectFields->NextSceneGuid = data->GetGuid().string();
                 }
             }
             ImGui::EndDragDropTarget();
@@ -25,5 +25,5 @@ NewGame::~NewGame() = default;
 
 void NewGame::Submit()
 {
-    UmSceneManager.LoadScene(ReflectFields->NextScene);
+    UmSceneManager.LoadScene(ReflectFields->NextSceneGuid);
 }

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/MainMenu/NewGame.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/MainMenu/NewGame.h
@@ -14,11 +14,11 @@ public:
 
 public:
     REFLECT_PROPERTY(NextScene)
-    GETTER_ONLY(std::string, NextScene) { return ReflectFields->NextScene; }
+    GETTER_ONLY(std::string, NextScene) { return File::Guid(ReflectFields->NextSceneGuid).ToPath().string(); }
     PROPERTY(NextScene)
 
 protected:
     REFLECT_FIELDS_BEGIN(MainMenuNavigationBase)
-    std::string NextScene;
+    std::string NextSceneGuid;
     REFLECT_FIELDS_END(NewGame)
 };

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/MainMenu/Option.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/MainMenu/Option.cpp
@@ -22,7 +22,10 @@ void Option::Update()
     if (_onDirtyFlag)
     {
         _onDirtyFlag = false;
-        _preferencesManager->OnPreferencesWindow();
+        if (_preferencesManager)
+        {
+            _preferencesManager->OnPreferencesWindow(this);
+        }
     }
 }
 

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Preferences/PreferencesManager.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Preferences/PreferencesManager.cpp
@@ -158,6 +158,11 @@ void PreferencesManager::OffPreferencesWindow()
 {
     _isOpen      = false;
     _isOpenDirty = true;
+    if (_backComponent)
+    {
+        _backComponent->Focus();
+    }
+    _backComponent = nullptr;
 }
 
 
@@ -183,10 +188,11 @@ void PreferencesManager::CloseAbandonButtons()
     _isOpenAbandonButton = false;
 }
 
-void PreferencesManager::OnPreferencesWindow() 
+void PreferencesManager::OnPreferencesWindow(UINavigationComponent* backComponent) 
 {
     _isOpen      = true;
     _isOpenDirty = true;
+    _backComponent = backComponent;
 }
 
 void PreferencesManager::GoToMainMenu()

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Preferences/PreferencesManager.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Preferences/PreferencesManager.h
@@ -29,7 +29,7 @@ public:
     void AddAbandonButton(Component* comps);
     void OpenAbadonButtons();
     void CloseAbandonButtons();
-    void OnPreferencesWindow();
+    void OnPreferencesWindow(UINavigationComponent* backComponent);
     void GoToMainMenu();
     bool IsOpen() { return _opened; }
 
@@ -64,4 +64,5 @@ private:
     bool                    _isOpenAbandonButton = false;
     bool                    _isOpenAbandonDirty  = false;
     bool                    _changeMainMenuSceneDirty = false;
+    UINavigationComponent*  _backComponent            = nullptr;
 };

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/System/QTESystem.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/System/QTESystem.cpp
@@ -37,7 +37,7 @@ void QTESystem::Awake()
         UmLogger.Log(LogLevel::LEVEL_ERROR, (const char*)u8"씬에 QTESystem이 2개 이상 존재하는지 확인해주세요.");
     }
 
-    if (QTEUIManager* uiManager = QTEUIManager::GetInstance())
+    if (QTEUIManager* uiManager = QTEUIManager::GetInstance(); uiManager)
     {
         uiManager->Refesh();
         uiManager->SetUIAlpha(0.0f);

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/System/QTESystem.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/System/QTESystem.cpp
@@ -39,7 +39,7 @@ void QTESystem::Awake()
 
     if (QTEUIManager* uiManager = QTEUIManager::GetInstance(); uiManager)
     {
-        uiManager->Refesh();
+        uiManager->Refresh();
         uiManager->SetUIAlpha(0.0f);
         uiManager->SetBackgroundUIAlpha(0.0f);
     }

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/System/QTESystem.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/System/QTESystem.h
@@ -72,6 +72,12 @@ public:
     /// <param name="pause"></param>
     void PauseQTE(bool pause);
 
+    /// <summary>
+    /// 전투 UI의 활성화 상태를 설정합니다.
+    /// </summary>
+    /// <param name="active">전투 UI를 활성화할지 여부를 지정하는 불리언 값입니다.</param>
+    void CombatUIActive(bool active);
+
 private:
     void ClearTrack();
     void ClearQueue();
@@ -93,7 +99,6 @@ private:
     void ProcessQTEFadeInEndEvent();
     void ProcessQTEFadeOutEndEvent();
 
-    void CombatUIActive(bool active);
 
 public:
     inline bool  IsQTEPlaying() const { return _currQTEPlaying; }

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.cpp
@@ -111,7 +111,7 @@ void QTEUIManager::OnQTEExit()
     ClearAllQTENotes();
 }
 
-void QTEUIManager::Refesh() 
+void QTEUIManager::Refresh() 
 {
     FindUIComponents();
     UpdateUITransformData();
@@ -393,7 +393,7 @@ void QTEUIManager::UpdateUITransformData()
     if (camera)
     {
         auto enemies = Battle::GetTargetsFromFlags(Battle::ENEMY_TARGET_FLAG_ALL);
-        if (3 == enemies.size())
+        if (3 <= enemies.size())
         {
             auto* left   = enemies[0];
             auto* middle = enemies[1];

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.cpp
@@ -252,6 +252,18 @@ void QTEUIManager::ImGuiDrawPropertysEvent()
     {
         FindUIComponents();
     }
+
+    if (ImGui::TreeNodeEx("Debug##qte_manager", ImGuiTreeNodeFlags_DefaultOpen))
+    {
+        ImGui::Text((const char*)u8"QTE Panel Absolute Pos : (%.1f, %.1f)", _qtePanelPos.x, _qtePanelPos.y);
+        ImGui::Text((const char*)u8"QTE Judge Absolute Pos : (%.1f, %.1f)", _qteJudgePos.x, _qteJudgePos.y);
+        // Guide Note Pos
+        ImGui::Text((const char*)u8"Guide Note X Absolute Pos : (%.1f, %.1f)", _qteGuideNoteXPos.x, _qteGuideNoteXPos.y);
+        ImGui::Text((const char*)u8"Guide Note Y Absolute Pos : (%.1f, %.1f)", _qteGuideNoteYPos.x, _qteGuideNoteYPos.y);
+        ImGui::Text((const char*)u8"Guide Note B Absolute Pos : (%.1f, %.1f)", _qteGuideNoteBPos.x, _qteGuideNoteBPos.y);
+
+        ImGui::TreePop();
+    }
 }
 
 void QTEUIManager::SetNotePrefabGuid(const File::Guid& guid) 

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.cpp
@@ -4,7 +4,10 @@
 #include <QTE/Track/QTETrack.h>
 #include <UI/Panels/Overlay/OverlayPanel.h>
 #include <UI/Elements/Image/ImageElement.h>
+#include <Camera/CameraComponent.h>
 
+#include <BattleSystem/Battle.h>
+#include <TurnSystem/TurnActor/Character/Enemy/Enemy.h>
 
 UMREAL_COMPONENT(QTEUIManager)
 
@@ -155,6 +158,7 @@ void QTEUIManager::Start()
         if (QTESystem* system = SingletonComponent<QTESystem>::GetInstance())
         {
             system->ProcessQTEFadeInEndEvent();
+            _fader.SetFadeMode(Fader::FADE_NONE);
         }
     });
     _fader.SetOnFadeOutEndCallback([this]() {
@@ -162,6 +166,7 @@ void QTEUIManager::Start()
         if (QTESystem* system = SingletonComponent<QTESystem>::GetInstance())
         {
             system->ProcessQTEFadeOutEndEvent();
+            _fader.SetFadeMode(Fader::FADE_NONE);
         }
     });
 }
@@ -169,8 +174,23 @@ void QTEUIManager::Start()
 void QTEUIManager::Update() 
 {
     float alpha = _fader.Fade();
-    SetBackgroundUIAlpha(alpha);
-    SetUIAlpha(alpha);
+    auto  mode  = _fader.GetFadeMode();
+    switch (mode)
+    {
+        case QTEUIManager::Fader::FADE_NONE:
+            break;
+        case QTEUIManager::Fader::FADE_IN: {
+            SetUIAlpha(alpha);
+            break;
+        }
+        case QTEUIManager::Fader::FADE_OUT: {
+            SetUIAlpha(alpha);
+            SetBackgroundUIAlpha(alpha);
+            break;
+        }
+        default:
+            break;
+    }
 }
 
 void QTEUIManager::OnEnable() 
@@ -237,7 +257,24 @@ void QTEUIManager::SetBackgroundUIAlpha(float factor)
     }
 }
 
-void QTEUIManager::SetUIAlpha(float factor) 
+void QTEUIManager::SetGuideNoteAlpha(float factor) 
+{
+    factor = std::clamp(factor, 0.0f, 1.0f);
+    if (_qteGuideNoteX)
+    {
+        _qteGuideNoteX->Alpha = factor;
+    }
+    if (_qteGuideNoteY)
+    {
+        _qteGuideNoteY->Alpha = factor;
+    }
+    if (_qteGuideNoteB)
+    {
+        _qteGuideNoteB->Alpha = factor;
+    }
+}
+
+void QTEUIManager::SetUIAlpha(float factor)
 {
     factor = std::clamp(factor, 0.0f, 1.0f);
     if (_qteNoteLineUI)
@@ -248,6 +285,11 @@ void QTEUIManager::SetUIAlpha(float factor)
     {
         _qteJudgeNoteUI->Alpha = factor;
     }
+}
+
+void QTEUIManager::SetActive(bool active) 
+{
+    gameObject->ActiveSelf = active;
 }
 
 void QTEUIManager::UpdateUITransformData()
@@ -268,6 +310,33 @@ void QTEUIManager::UpdateUITransformData()
         SIZE size     = _qteJudgeNoteUI->Size;
         _qteJudgeSize = Vector2((float)size.cx, (float)size.cy);
     }
+
+    CameraComponent* camera = CameraComponent::MainCamera();
+    if (camera)
+    {
+        auto enemies = Battle::GetTargetsFromFlags(Battle::ENEMY_TARGET_FLAG_ALL);
+        if (3 == enemies.size())
+        {
+            auto* left   = enemies[0];
+            auto* middle = enemies[0];
+            auto* right  = enemies[0];
+            if (left && _qteGuideNoteX)
+            {
+                Vector3 pos = camera->WorldToViewport(left->transform->GetWorldPosition());
+                _qteGuideNoteX->Point = POINT((LONG)pos.x, (LONG)pos.y);
+            }
+            if (middle && _qteGuideNoteY)
+            {
+                Vector3 pos = camera->WorldToViewport(middle->transform->GetWorldPosition());
+                _qteGuideNoteX->Point = POINT((LONG)pos.x, (LONG)pos.y);
+            }
+            if (right && _qteGuideNoteB)
+            {
+                Vector3 pos = camera->WorldToViewport(right->transform->GetWorldPosition());
+                _qteGuideNoteX->Point = POINT((LONG)pos.x, (LONG)pos.y);
+            }
+        }
+    }
 }
 
 bool QTEUIManager::CheckUIValid()
@@ -277,9 +346,13 @@ bool QTEUIManager::CheckUIValid()
 
 void QTEUIManager::FindUIComponents()
 {
-    _qteOverlayPanel = nullptr;
-    _qteNoteLineUI = nullptr;
-    _qteJudgeNoteUI = nullptr;
+    _qteOverlayPanel    = nullptr;
+    _qteBackgroundUI    = nullptr;
+    _qteNoteLineUI      = nullptr;
+    _qteJudgeNoteUI     = nullptr;
+    _qteGuideNoteX      = nullptr;
+    _qteGuideNoteY      = nullptr;
+    _qteGuideNoteB      = nullptr;
 
     Transform::ForeachBFS(transform, [this](Transform* curr) {
         if (!_qteOverlayPanel && curr->gameObject->CompareTag("QTE Panel"))
@@ -298,6 +371,18 @@ void QTEUIManager::FindUIComponents()
         {
             _qteJudgeNoteUI = curr->gameObject->GetComponent<ImageElement>();
         }
+        else if (!_qteGuideNoteX && curr->gameObject->CompareTag("Guide Note X"))
+        {
+            _qteGuideNoteX = curr->gameObject->GetComponent<ImageElement>();
+        }
+        else if (!_qteGuideNoteY && curr->gameObject->CompareTag("Guide Note Y"))
+        {
+            _qteGuideNoteY = curr->gameObject->GetComponent<ImageElement>();
+        }
+        else if (!_qteGuideNoteB && curr->gameObject->CompareTag("Guide Note B"))
+        {
+            _qteGuideNoteB = curr->gameObject->GetComponent<ImageElement>();
+        }
     });
 
     if (nullptr == _qteOverlayPanel)
@@ -311,6 +396,18 @@ void QTEUIManager::FindUIComponents()
     if (nullptr == _qteJudgeNoteUI)
     {
         UmLogger.Log(LogLevel::LEVEL_WARNING, (const char*)u8"QTE Judge Note UI를 찾지 못했습니다.");
+    }
+    if (nullptr == _qteGuideNoteX)
+    {
+        UmLogger.Log(LogLevel::LEVEL_WARNING, (const char*)u8"Guide Note X를 찾지 못했습니다.");
+    }
+    if (nullptr == _qteGuideNoteY)
+    {
+        UmLogger.Log(LogLevel::LEVEL_WARNING, (const char*)u8"Guide Note Y를 찾지 못했습니다.");
+    }
+    if (nullptr == _qteGuideNoteB)
+    {
+        UmLogger.Log(LogLevel::LEVEL_WARNING, (const char*)u8"Guide Note B를 찾지 못했습니다.");
     }
 }
 

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.cpp
@@ -22,7 +22,7 @@ void QTEUIManager::OnQTEEnter()
     }
     // 오브젝트 활성화 QTE UI 페이드 인 시작
     gameObject->ActiveSelf = true;
-    _fader.SetFadeMode(Fader::FADE_IN);
+    _mainFader.SetFadeMode(Fader::FADE_IN);
     
     // QTE UI 위치 및 크기 데이터 저장
     UpdateUITransformData();
@@ -105,7 +105,7 @@ void QTEUIManager::OnQTEStay()
 void QTEUIManager::OnQTEExit() 
 {
     // QTE UI 페이드 아웃 
-    _fader.SetFadeMode(Fader::FADE_OUT);
+    _mainFader.SetFadeMode(Fader::FADE_OUT);
     
     // QTE 종료 시 노트 오브젝트 정리
     ClearAllQTENotes();
@@ -151,46 +151,58 @@ void QTEUIManager::Awake()
 
 void QTEUIManager::Start()
 {
-    _fader.SetDuration(1.0f);
-    _fader.SetFadeInType(Mathf::EASE_IN, Mathf::SINE);
-    _fader.SetFadeOutType(Mathf::EASE_OUT, Mathf::SINE);
-    _fader.SetOnFadeInEndCallback([this]() {
+    _mainFader.SetDuration(1.0f);
+    _mainFader.SetFadeInType(Mathf::EASE_IN, Mathf::SINE);
+    _mainFader.SetFadeOutType(Mathf::EASE_OUT, Mathf::SINE);
+    _mainFader.SetOnFadeInEndCallback([this]() {
         if (QTESystem* system = SingletonComponent<QTESystem>::GetInstance())
         {
             system->ProcessQTEFadeInEndEvent();
-            _fader.SetFadeMode(Fader::FADE_NONE);
+            _mainFader.SetFadeMode(Fader::FADE_NONE);
         }
     });
-    _fader.SetOnFadeOutEndCallback([this]() {
+    _mainFader.SetOnFadeOutEndCallback([this]() {
         gameObject->ActiveSelf = false;
         if (QTESystem* system = SingletonComponent<QTESystem>::GetInstance())
         {
             system->ProcessQTEFadeOutEndEvent();
-            _fader.SetFadeMode(Fader::FADE_NONE);
+            _mainFader.SetFadeMode(Fader::FADE_NONE);
         }
     });
+
+    _xybAlphaFader.SetFadeInType(Mathf::EASE_IN, Mathf::SINE);
+    _xybAlphaFader.SetFadeOutType(Mathf::EASE_OUT, Mathf::SINE);
+    _xybAlphaFader.SetOnFadeInEndCallback([this]() { _xybAlphaFader.SetFadeMode(Fader::FADE_NONE); });
+    _xybAlphaFader.SetOnFadeOutEndCallback([this]() { _xybAlphaFader.SetFadeMode(Fader::FADE_NONE); });
+
+    _xybPointFader.SetFadeInType(Mathf::EASE_OUT, Mathf::SINE);
+    _xybPointFader.SetFadeOutType(Mathf::EASE_OUT, Mathf::SINE);
+    _xybPointFader.SetOnFadeInEndCallback([this]() { _xybPointFader.SetFadeMode(Fader::FADE_NONE); });
+    _xybPointFader.SetOnFadeOutEndCallback([this]() { _xybPointFader.SetFadeMode(Fader::FADE_NONE); });
 }
 
 void QTEUIManager::Update() 
 {
-    float alpha = _fader.Fade();
-    auto  mode  = _fader.GetFadeMode();
+    float factor = _mainFader.Fade();
+    auto  mode  = _mainFader.GetFadeMode();
     switch (mode)
     {
         case QTEUIManager::Fader::FADE_NONE:
             break;
         case QTEUIManager::Fader::FADE_IN: {
-            SetUIAlpha(alpha);
+            SetUIAlpha(factor);
             break;
         }
         case QTEUIManager::Fader::FADE_OUT: {
-            SetUIAlpha(alpha);
-            SetBackgroundUIAlpha(alpha);
+            SetUIAlpha(factor);
+            SetBackgroundUIAlpha(factor);
             break;
         }
         default:
             break;
     }
+
+    UpdateGuideNoteUI();
 }
 
 void QTEUIManager::OnEnable() 
@@ -292,6 +304,72 @@ void QTEUIManager::SetActive(bool active)
     gameObject->ActiveSelf = active;
 }
 
+void QTEUIManager::StartShowQTEGuideNote() 
+{
+    _xybOutTimer = 0.0f;
+    _xybPointFader.SetTimer(0.0f);
+    _xybAlphaFader.SetTimer(0.0f);
+
+    _xybAlphaFader.SetDuration(0.5f);
+    _xybPointFader.SetDuration(1.0f);
+    _xybAlphaFader.SetFadeMode(Fader::FADE_IN);
+    _xybPointFader.SetFadeMode(Fader::FADE_IN);
+}
+
+void QTEUIManager::StartHideQTEGuideNote() 
+{
+    _xybAlphaFader.SetDuration(0.5f);
+    _xybPointFader.SetDuration(1.0f);
+    _xybAlphaFader.SetFadeMode(Fader::FADE_OUT);
+    _xybPointFader.SetFadeMode(Fader::FADE_OUT);
+}
+
+void QTEUIManager::UpdateGuideNoteUI() 
+{
+    _xybAlphaFader.Fade();
+    _xybPointFader.Fade();
+
+    POINT point;
+    const SIZE& resolution  = UmGraphics.GetResolution();
+    const float minY        = static_cast<float>(resolution.cy);
+    const float alphaFactor = _xybAlphaFader.GetFadeFactor();
+    const float pointFactor = _xybPointFader.GetFadeFactor();
+    
+    if (_qteGuideNoteX)
+    {
+        SIZE size             = _qteGuideNoteX->Size;
+        point.x               = (LONG)_qteGuideNoteXPos.x - size.cx / 2;
+        point.y               = (LONG)std::lerp(minY, 0, pointFactor) - size.cy / 2;
+        _qteGuideNoteX->Point = point;
+        _qteGuideNoteX->Alpha = alphaFactor;
+    }
+    if (_qteGuideNoteY)
+    {
+        SIZE size             = _qteGuideNoteY->Size;
+        point.x               = (LONG)_qteGuideNoteYPos.x - size.cx / 2;
+        point.y               = (LONG)std::lerp(minY, 0, pointFactor) - size.cy / 2;
+        _qteGuideNoteY->Point = point;
+        _qteGuideNoteY->Alpha = alphaFactor;
+    }
+    if (_qteGuideNoteB)
+    {
+        SIZE size             = _qteGuideNoteB->Size;
+        point.x               = (LONG)_qteGuideNoteBPos.x - size.cx / 2;
+        point.y               = (LONG)std::lerp(minY, 0, pointFactor) - size.cy / 2;
+        _qteGuideNoteB->Point = point;
+        _qteGuideNoteB->Alpha = alphaFactor;
+    }
+
+    if (_xybPointFader.IsFadeInEnd())
+    {
+        _xybOutTimer += UmTime.DeltaTime();
+        if (_xybOutTimer >= 1.0f)
+        {
+            StartHideQTEGuideNote();
+        }
+    }
+}
+
 void QTEUIManager::UpdateUITransformData()
 {
     if (_qteOverlayPanel)
@@ -318,22 +396,19 @@ void QTEUIManager::UpdateUITransformData()
         if (3 == enemies.size())
         {
             auto* left   = enemies[0];
-            auto* middle = enemies[0];
-            auto* right  = enemies[0];
+            auto* middle = enemies[1];
+            auto* right  = enemies[2];
             if (left && _qteGuideNoteX)
             {
-                Vector3 pos = camera->WorldToViewport(left->transform->GetWorldPosition());
-                _qteGuideNoteX->Point = POINT((LONG)pos.x, (LONG)pos.y);
+                _qteGuideNoteXPos = camera->WorldToViewport(left->transform->GetWorldPosition());
             }
             if (middle && _qteGuideNoteY)
             {
-                Vector3 pos = camera->WorldToViewport(middle->transform->GetWorldPosition());
-                _qteGuideNoteX->Point = POINT((LONG)pos.x, (LONG)pos.y);
+                _qteGuideNoteYPos = camera->WorldToViewport(middle->transform->GetWorldPosition());
             }
             if (right && _qteGuideNoteB)
             {
-                Vector3 pos = camera->WorldToViewport(right->transform->GetWorldPosition());
-                _qteGuideNoteX->Point = POINT((LONG)pos.x, (LONG)pos.y);
+                _qteGuideNoteBPos = camera->WorldToViewport(right->transform->GetWorldPosition());
             }
         }
     }

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.h
@@ -38,7 +38,7 @@ public:
     /// <summary>
     /// UI데이터를 갱신합니다.
     /// </summary>
-    void Refesh();
+    void Refresh();
 
     /// <summary>노트 프리팹의 GUID를 설정합니다. 해당 프리팹을 통해 QTE 노트 UI가 생성됩니다.</summary>
     /// <param name="guid">설정할 File::Guid 객체입니다.</param>

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.h
@@ -63,6 +63,10 @@ public:
     /// <param name="active">객체를 활성화할지 여부를 지정하는 불리언 값입니다.</param>
     void SetActive(bool active);
 
+    void StartShowQTEGuideNote();
+    void StartHideQTEGuideNote();
+    void UpdateGuideNoteUI();
+
 private:
     void Reset() override;
     void Awake() override;
@@ -92,14 +96,10 @@ private:
 
 private:
 
-
     OverlayPanel*   _qteOverlayPanel    = nullptr;
     ImageElement*   _qteBackgroundUI    = nullptr;
     ImageElement*   _qteNoteLineUI      = nullptr;
     ImageElement*   _qteJudgeNoteUI     = nullptr;
-    ImageElement*   _qteGuideNoteX      = nullptr;
-    ImageElement*   _qteGuideNoteY      = nullptr;
-    ImageElement*   _qteGuideNoteB      = nullptr;
     File::GuidRef   _notePrefabGuid     = File::NULL_GUID;
     std::unordered_map<int, ImageElement*> _noteSpawnTable = {};
 
@@ -201,5 +201,15 @@ private:
         std::function<void()> _onFadeInEndCallback = nullptr;
         std::function<void()> _onFadeOutEndCallback = nullptr;
     };
-    Fader _fader;
+    Fader _mainFader;
+
+    float         _xybOutTimer      = 0.0f;
+    ImageElement* _qteGuideNoteX    = nullptr;
+    ImageElement* _qteGuideNoteY    = nullptr;
+    ImageElement* _qteGuideNoteB    = nullptr;
+    Vector3       _qteGuideNoteXPos = Vector3::Zero;
+    Vector3       _qteGuideNoteYPos = Vector3::Zero;
+    Vector3       _qteGuideNoteBPos = Vector3::Zero;
+    Fader         _xybAlphaFader;
+    Fader         _xybPointFader;
 };

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/QTE/UI/QTEUIManager.h
@@ -10,6 +10,7 @@ namespace QTE
 class QTESystem;
 class OverlayPanel;
 class ImageElement;
+class CameraComponent;
 
 class QTEUIManager : public Component
 {
@@ -48,9 +49,19 @@ public:
     /// <param name="factor">설정할 UI의 알파 값입니다. 0.0f에서 1.0f 사이의 값을 가집니다.</param>
     void SetBackgroundUIAlpha(float factor);
 
+    /// <summary>
+    /// 가이드 노트의 알파 값을 설정합니다.
+    /// </summary>
+    /// <param name="factor">설정할 알파 값입니다. 0.0f에서 1.0f 사이의 값을 가집니다.</param>
+    void SetGuideNoteAlpha(float factor);
+
     /// <summary>QTE 관련 UI의 알파 값을 설정합니다. (백그라운드는 제외입니다.)</summary>
     /// <param name="factor">설정할 UI의 알파 값입니다. 0.0f에서 1.0f 사이의 값을 가집니다.</param>
     void SetUIAlpha(float factor);
+
+    /// <summary>객체의 활성 상태를 설정합니다.</summary>
+    /// <param name="active">객체를 활성화할지 여부를 지정하는 불리언 값입니다.</param>
+    void SetActive(bool active);
 
 private:
     void Reset() override;
@@ -80,10 +91,15 @@ private:
     ImageElement* FindNoteUIFromNoteID(int noteID) const;
 
 private:
+
+
     OverlayPanel*   _qteOverlayPanel    = nullptr;
     ImageElement*   _qteBackgroundUI    = nullptr;
     ImageElement*   _qteNoteLineUI      = nullptr;
     ImageElement*   _qteJudgeNoteUI     = nullptr;
+    ImageElement*   _qteGuideNoteX      = nullptr;
+    ImageElement*   _qteGuideNoteY      = nullptr;
+    ImageElement*   _qteGuideNoteB      = nullptr;
     File::GuidRef   _notePrefabGuid     = File::NULL_GUID;
     std::unordered_map<int, ImageElement*> _noteSpawnTable = {};
 

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/TurnSystem/TurnActor/Character/Player/State/PlayerPlayTurnState.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/TurnSystem/TurnActor/Character/Player/State/PlayerPlayTurnState.cpp
@@ -50,6 +50,11 @@ void PlayerPlayTurnState::OnEnter()
     _setImguiPosCenter    = true;
     _attackButtonHeldTime = 0;
     _attackRemaining      = 0;
+
+    if (QTEUIManager* qteUIManager = QTEUIManager::GetInstance())
+    {
+        qteUIManager->Refesh();
+    }
 }
 
 void PlayerPlayTurnState::OnExit() 
@@ -136,6 +141,15 @@ void PlayerPlayTurnState::UpdateActionSelectionUI(float dt)
         }
         float t = _attackButtonHeldTime / _attackButtonHeldWaitTime;
         ImGui::ProgressBar(t);
+        QTESystem*      qteSystem = SingletonComponent<QTESystem>::GetInstance();
+        QTEUIManager*   qteUIManager = QTEUIManager::GetInstance(); 
+        if (qteSystem && qteUIManager)
+        {
+            qteSystem->CombatUIActive(!_isDownAButton);
+            qteUIManager->SetBackgroundUIAlpha(t);
+            qteUIManager->SetUIAlpha(0.0f);
+            qteUIManager->SetActive(true);
+        }
     }
     ImGui::End();
     ImGui::PopStyleColor();

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/TurnSystem/TurnActor/Character/Player/State/PlayerPlayTurnState.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/TurnSystem/TurnActor/Character/Player/State/PlayerPlayTurnState.cpp
@@ -53,7 +53,7 @@ void PlayerPlayTurnState::OnEnter()
 
     if (QTEUIManager* qteUIManager = QTEUIManager::GetInstance())
     {
-        qteUIManager->Refesh();
+        qteUIManager->Refresh();
     }
 }
 

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/TurnSystem/TurnActor/Character/Player/State/PlayerPlayTurnState.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/TurnSystem/TurnActor/Character/Player/State/PlayerPlayTurnState.cpp
@@ -101,11 +101,19 @@ void PlayerPlayTurnState::OnUpdate()
 void PlayerPlayTurnState::PressedButtonA(const Input::Controller& controller)
 {
     _isDownAButton = true;
+    if (QTEUIManager* qteUIManager = QTEUIManager::GetInstance())
+    {
+        qteUIManager->StartShowQTEGuideNote();
+    }
 }
 
 void PlayerPlayTurnState::ReleasedButtonA(const Input::Controller& controller)
 {
     _isDownAButton = false;
+    if (QTEUIManager* qteUIManager = QTEUIManager::GetInstance())
+    {
+        qteUIManager->StartHideQTEGuideNote();
+    }
 }
 
 void PlayerPlayTurnState::UpdateAttackButtonHeld(float dt)
@@ -131,28 +139,28 @@ void PlayerPlayTurnState::UpdateAttackButtonHeld(float dt)
 
 void PlayerPlayTurnState::UpdateActionSelectionUI(float dt) 
 {
-    ImGuiWindowFlags flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar;
-    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.1f, 0.1f, 0.1f, 0.5f));
-    ImGui::Begin("Player Turn##9A48EE30-CB5F-48AC-9740-DDF8118AAC49", nullptr, flags);
+    //ImGuiWindowFlags flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar;
+    //ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.1f, 0.1f, 0.1f, 0.5f));
+    //ImGui::Begin("Player Turn##9A48EE30-CB5F-48AC-9740-DDF8118AAC49", nullptr, flags);
+    //{
+    //    if (ImGui::Button((const char*)u8"A를 눌러 공격 진입"))
+    //    {
+    //        _attackButtonHeldTime = _attackButtonHeldWaitTime;
+    //    }
+    //}
+    //ImGui::End();
+    //ImGui::PopStyleColor();
+
+    float t = _attackButtonHeldTime / _attackButtonHeldWaitTime;
+    QTESystem*    qteSystem    = SingletonComponent<QTESystem>::GetInstance();
+    QTEUIManager* qteUIManager = QTEUIManager::GetInstance();
+    if (qteSystem && qteUIManager)
     {
-        if (ImGui::Button((const char*)u8"A를 눌러 공격 진입"))
-        {
-            _attackButtonHeldTime = _attackButtonHeldWaitTime;
-        }
-        float t = _attackButtonHeldTime / _attackButtonHeldWaitTime;
-        ImGui::ProgressBar(t);
-        QTESystem*      qteSystem = SingletonComponent<QTESystem>::GetInstance();
-        QTEUIManager*   qteUIManager = QTEUIManager::GetInstance(); 
-        if (qteSystem && qteUIManager)
-        {
-            qteSystem->CombatUIActive(!_isDownAButton);
-            qteUIManager->SetBackgroundUIAlpha(t);
-            qteUIManager->SetUIAlpha(0.0f);
-            qteUIManager->SetActive(true);
-        }
+        qteSystem->CombatUIActive(!_isDownAButton);
+        qteUIManager->SetBackgroundUIAlpha(t);
+        qteUIManager->SetUIAlpha(0.0f);
+        qteUIManager->SetActive(true);
     }
-    ImGui::End();
-    ImGui::PopStyleColor();
 }
 
 void PlayerPlayTurnState::UpdateQuickTimeEventUI(float dt)


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/VG-373/main_menu_fix

---

## 🛠️ 변경 사항
- QTE 가이드 버튼 출력 함수 추가
- 플레이어 턴 A홀드 액션 추가 (ImGui 사용
- MainMenu의 NewGame이 Path가 아닌 Guid를 저장하도록 변경
- 카메라 컴포넌트의 WolrdToViewPort함수 제대로 동작되도록 곱셈 연산 수정

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?
