### PR TITLE
[FIX/VG-28] 에디터 모드의 오브젝트 삭제 타이밍 문제 해결

### DIFF
--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.cpp
@@ -605,9 +605,9 @@ void EditorHierarchyTool::HierarchyDrawTreeNode()
         //유효한 오브젝트만 남긴다.
         if (_hierarchyObjectCleanup)
         {
-            std::erase_if(_hierarchyObjects, [](const std::shared_ptr<GameObject>& object) 
+            std::erase_if(_hierarchyObjects, [](const std::weak_ptr<GameObject>& object) 
             {
-                return false == object->IsValid();
+                return false == object.expired();
             });
             _hierarchyObjectCleanup = false;
         }
@@ -624,28 +624,36 @@ void EditorHierarchyTool::HierarchyDrawTreeNode()
             {
                 const std::string& name = scene->Path;
                 _hierarchySceneIndex[name] = _hierarchyRootObjects.size();
-                _hierarchyRootObjects.emplace_back(name, std::vector<GameObject*>());
+                _hierarchyRootObjects.emplace_back(name, std::vector<std::shared_ptr<GameObject>>());
             }
 
             //분류 작업
-            for (auto& object : _hierarchyObjects)
+            for (auto& weakObject : _hierarchyObjects)
             {
-                if (nullptr == object->transform->Parent)
+                std::shared_ptr<GameObject> object = weakObject.lock();
+                if (object)
                 {
-                    const std::string& ownerSceneName = object->GetOwnerSceneName();
-                    auto sceneIndexIter = _hierarchySceneIndex.find(ownerSceneName);
-                    if (sceneIndexIter != _hierarchySceneIndex.end())
+                    if (nullptr == object->transform->Parent)
                     {
-                        size_t sceneIndex = sceneIndexIter->second;
-                        _hierarchyRootObjects[sceneIndex].second.push_back(object.get());
-                    }
-                    else
-                    {
-                        if (ownerSceneName == ESceneManager::DONT_DESTROY_ON_LOAD_SCENE_NAME)
+                        const std::string& ownerSceneName = object->GetOwnerSceneName();
+                        auto               sceneIndexIter = _hierarchySceneIndex.find(ownerSceneName);
+                        if (sceneIndexIter != _hierarchySceneIndex.end())
                         {
-                            _hierarchyDontDestroyOnLoadObjects.push_back(object.get());
+                            size_t sceneIndex = sceneIndexIter->second;
+                            _hierarchyRootObjects[sceneIndex].second.push_back(object);
+                        }
+                        else
+                        {
+                            if (ownerSceneName == ESceneManager::DONT_DESTROY_ON_LOAD_SCENE_NAME)
+                            {
+                                _hierarchyDontDestroyOnLoadObjects.push_back(std::move(object));
+                            }
                         }
                     }
+                }           
+                else
+                {
+                    _hierarchyObjectCleanup = true;
                 }
             }
 
@@ -723,7 +731,7 @@ void EditorHierarchyTool::HierarchyDrawTreeNode()
                     {
                         for (auto& obj : _hierarchyDontDestroyOnLoadObjects)
                         {
-                            ImGui::PushID(obj);
+                            ImGui::PushID(obj.get());
                             {
                                 GameObject* clickNode = nullptr;
                                 TransformTreeNode(obj->transform, focusObject, clickNode, static_isOpenFocusObj);

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.h
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Editor/Tool/Hierarchy/EditorHierarchyTool.h
@@ -130,11 +130,11 @@ private:
     HierarchyFindTool* _editorFindTool = nullptr;
 
     //오브젝트 항목
-    std::unordered_map<std::string, size_t>                       _hierarchySceneIndex;
-    std::vector<std::pair<std::string, std::vector<GameObject*>>> _hierarchyRootObjects;
-    std::vector<GameObject*>                                      _hierarchyDontDestroyOnLoadObjects;
-    std::vector<std::shared_ptr<GameObject>>                      _hierarchyObjects;
-    bool                                                          _hierarchyObjectCleanup = false;
+    std::unordered_map<std::string, size_t>                                       _hierarchySceneIndex;
+    std::vector<std::pair<std::string, std::vector<std::shared_ptr<GameObject>>>> _hierarchyRootObjects;
+    std::vector<std::shared_ptr<GameObject>>                                      _hierarchyDontDestroyOnLoadObjects;
+    std::vector<std::weak_ptr<GameObject>>                                        _hierarchyObjects;
+    bool                                                                          _hierarchyObjectCleanup = false;
 
 protected: 
     REFLECT_FIELDS_BEGIN(EditorTool)

--- a/Source/GA6thFinal_Framework/GameEngine/Source/Engine/AppModule/ImGuiDX12Module.cpp
+++ b/Source/GA6thFinal_Framework/GameEngine/Source/Engine/AppModule/ImGuiDX12Module.cpp
@@ -26,16 +26,16 @@ void ImGuiDX12Module::PreInitialize()
     fontConfig.OversampleV = 3;
     fontConfig.PixelSnapH  = true;
 
-    // 유니코드 범위 설정 (한글 + 로마 숫자 포함)
-    static const ImWchar customRanges[] = {
-        0x0020, 0x00FF, // 기본 라틴
-        0x1100, 0x11FF, // 한글 자모
-        0x3130, 0x318F, // 한글 자모 (호환)
-        0xAC00, 0xD7AF, // 한글 완성형
-        0x2160, 0x2188, // 로마 숫자!!!
-        0,              // 종료
-    };
-    ImFont* mainFont = io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\malgun.ttf", 20.0f, &fontConfig, customRanges);
+    ImVector<ImWchar> ranges;
+    ImFontGlyphRangesBuilder builder;
+    builder.AddRanges(io.Fonts->GetGlyphRangesDefault());
+    builder.AddRanges(io.Fonts->GetGlyphRangesKorean());
+    builder.AddChar((ImWchar)0x2163); // Ⅳ
+    builder.AddChar((ImWchar)0x2167); // Ⅷ
+    builder.AddChar((ImWchar)0x2169); // Ⅹ
+    builder.BuildRanges(&ranges);
+    
+    ImFont* mainFont = io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\malgun.ttf", 20.0f, &fontConfig, ranges.Data);
 
     std::string fontFileName = "Font Awesome 6 Free-Regular-400.ttf";
     auto        fontPath     = UmFileSystem.GetRootPath();


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-28/hierarchy_safe_erase

---

## 🛠️ 변경 사항
- 에디터 모드의 오브젝트 삭제 타이밍 문제 해결

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

