### PR TITLE
[FIX/VG-28] 설정창 GUID 사용 안하는 문제 해결

### DIFF
--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Preferences/PreferencesManager.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Preferences/PreferencesManager.cpp
@@ -12,9 +12,10 @@ PreferencesManager::PreferencesManager()
             if (const ImGuiPayload* payLoad = ImGui::AcceptDragDropPayload(DragDropAsset::KEY))
             {
                 const DragDropAsset::Data* data = static_cast<DragDropAsset::Data*>(payLoad->Data);
-                if (const auto extension = data->GetPath().extension(); extension == L".UmScene")
+                File::Path path = data->GetPath();
+                if (const auto extension = path.extension(); extension == L".UmScene")
                 {
-                    ReflectFields->MainMenuSceneStr = data->GetPath().string();
+                    ReflectFields->MainMenuSceneStr = data->GetGuid().string();
                 }
             }
             ImGui::EndDragDropTarget();
@@ -112,7 +113,11 @@ void PreferencesManager::LateUpdate()
     if (_changeMainMenuSceneDirty)
     {
         _changeMainMenuSceneDirty = false;
-        UmSceneManager.LoadScene(ReflectFields->MainMenuSceneStr);
+        File::Guid sceneGuid      = ReflectFields->MainMenuSceneStr;
+        if (File::Path path = sceneGuid.ToPath(); false == path.IsNull())
+        {
+            UmSceneManager.LoadScene(path.string());
+        }  
     }
 }
 

--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/Preferences/PreferencesManager.h
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/Preferences/PreferencesManager.h
@@ -42,7 +42,11 @@ private:
 
 public:
     REFLECT_PROPERTY(MainMenuScene)
-    GETTER_ONLY(std::string, MainMenuScene) { return ReflectFields->MainMenuSceneStr; }
+    GETTER_ONLY(std::string, MainMenuScene) 
+    {
+        File::Guid guid = ReflectFields->MainMenuSceneStr;
+        return guid.ToPath().string(); 
+    }
     PROPERTY(MainMenuScene)
 
 protected:


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- feature/VG-28/feature_name

---

## 🛠️ 변경 사항
- 설정창 GUID 사용 안하는 문제 해결

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

