### PR TITLE
[FEATURE/VG-415] 글꼴 두께 설정 기능 활성화

### DIFF
--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/UI/Elements/Text/TextElement.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/UI/Elements/Text/TextElement.cpp
@@ -187,7 +187,7 @@ void TextElement::UpdateWeight() const
 {
     if (nullptr != _renderer)
     {
-        //_renderer->SetFontWeight(ReflectFields->FontWeight);
+        _renderer->SetFontWeight(ReflectFields->FontWeight);
     }
 }
 


### PR DESCRIPTION
`TextElement::UpdateWeight` 함수에서 주석 처리된 코드가 제거되어, `_renderer->SetFontWeight(ReflectFields->FontWeight);`가 이제 실행됩니다. 이로 인해 글꼴 두께를 설정하는 기능이 활성화되었습니다.

## 🎯 반영 브랜치
develop <- fix/VG-415/ui
---

## 🛠️ 변경 사항
- 글꼴 두께

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
관련된 Git Issue 번호와 Jira Ticket Number 링크  
- Git Issue: #
- Jira Ticket Number: VG-415
