### PR TITLE
[FIX/VG-449] SDFTextRenderer 코드 정리 및 안전성 개선

### DIFF
--- a/Source/GA6thFinal_Framework/GraphicsEngine/SDFTextRenderer.cpp
+++ b/Source/GA6thFinal_Framework/GraphicsEngine/SDFTextRenderer.cpp
@@ -132,11 +132,7 @@ void SDFTextRenderer::Update(ID3D12GraphicsCommandList* commandList)
 
         float cursorX = 0;
         float cursorY = 0;
-
-        _charCount = 0;
-
-        // Left, Top, Right, Bottom
-        float calculatedBounds[4] = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+        _charCount    = 0;
 
         for (wchar_t wc : _text)
         {
@@ -219,6 +215,12 @@ void SDFTextRenderer::Render(ID3D12GraphicsCommandList* commandList)
 
 void SDFTextRenderer::MeasureString()
 {
+    if (!_font || _text.empty())
+    {
+        _size = Vector2::Zero;
+        return;
+    }
+
     const auto& metricsInfo         = _font->GetMetricsInfo();
     float       calculatedBounds[4] = {FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX};
     float       cursorX             = 0;
@@ -227,7 +229,7 @@ void SDFTextRenderer::MeasureString()
 
     for (wchar_t wc : _text)
     {
-        if (_charCount >= MAX_CHARS)
+        if (charCount >= MAX_CHARS)
             break;
 
         if (wc == L'\n')


### PR DESCRIPTION
   ## 🎯 반영 브랜치
   develop <- fix/VG-449/measure_string_error

   ---

   ## 🛠️ 변경 사항
   - MeasureString 함수에서 범위 검사 불일치 수정
   - null 체크 및 빈 텍스트 처리 안전 장치 추가
   - 사용되지 않는 calculatedBounds 변수 제거
   - 코드 가독성 및 메모리 안전성 개선

   ---

   ## ✅ 체크리스트
   - [x] 코드에 불필요한 로그는 제거했나요?
   - [x] 코드에 불필요한 주석은 제거했나요?
   - [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
   - [x] 코드 스타일 가이드를 따랐나요?

   ---

   ## 📎 참고 이슈
   관련된 Git Issue 번호와 Jira Ticket Number 링크
   - Git Issue: #603 
   - Jira Ticket Number: VG-436