### PR TITLE
[FIX/VG-468] DescriptionPanel BREAK 요소 처리 로직 개선

### DIFF
--- a/Source/GA6thFinal_Framework/GameScripts/Scripts/UI/Panels/Description/DescriptionPanel.cpp
+++ b/Source/GA6thFinal_Framework/GameScripts/Scripts/UI/Panels/Description/DescriptionPanel.cpp
@@ -231,9 +231,16 @@ void DescriptionPanel::MakeChild()
 
     for (const std::vector<ElementData> elementData = ParseData()(text); const auto& [Type, Data] : elementData)
     {
+        if (Type == ElementType::BREAK)
+        {
+            breakNext = true;
+            continue;
+        }
+
         const std::shared_ptr<GameObject> child =
             NewGameObject(GameObject::Helper::GenerateUniqueName("Description Child"));
         child->transform->SetParent(transform, true);
+
         if (breakNext)
         {
             if (HorizontalPanelSlot* slot = child->GetComponent<HorizontalPanelSlot>())
@@ -242,6 +249,7 @@ void DescriptionPanel::MakeChild()
             }
             breakNext = false;
         }
+
         switch (Type)
         {
         case ElementType::TEXT: {
@@ -273,9 +281,8 @@ void DescriptionPanel::MakeChild()
             imageChild->transform->SetParent(child->transform, true);
         }
         break;
-        case ElementType::BREAK: {
-            breakNext = true;
-        }
+        default:
+            break;
         }
     }
 }


### PR DESCRIPTION
## 🎯 반영 브랜치
develop <- fix/description_panel

---

## 🛠️ 변경 사항
- DescriptionPanel에서 BREAK 요소 처리 로직 개선
- BREAK 요소를 만났을 때 불필요한 자식 GameObject 생성 방지
- 다음 요소에만 줄바꿈이 적용되도록 로직 수정
- 코드 구조 개선 및 가독성 향상

---

## ✅ 체크리스트
- [x] 코드에 불필요한 로그는 제거했나요?
- [x] 코드에 불필요한 주석은 제거했나요?
- [x] 새로운 컴포넌트/함수에 대해 테스트 코드를 작성했나요?
- [x] 코드 스타일 가이드를 따랐나요?

---

## 📎 참고 이슈
- Jira Ticket Number: VG-468